### PR TITLE
public: Remove tabindex attributes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,10 +24,10 @@
       </div>
       <form class='edit-link'>
         <label>Custom link:</label>
-        <input class='u-full-width' tabindex='1' data-name='url'/>
+        <input class='u-full-width' data-name='url'/>
         <label>Redirect to:</label>
-        <input class='u-full-width' tabindex='2' data-name='location'/>
-        <button class='button button-primary' tabindex='3' data-name='submit'></button>
+        <input class='u-full-width' data-name='location'/>
+        <button class='button button-primary' data-name='submit'></button>
         <div class='result'></div>
       </form>
       <div class='result success'>


### PR DESCRIPTION
Since we're focusing elements automatically using JavaScript, and ordering keeping the markup clean to begin with, setting the tabindex attribute is unnecessary.