### PR TITLE
Extract cl.flashResult

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -294,7 +294,12 @@
     var linkForm = this.parentNode,
         resultFlash = linkForm.getElementsByClassName('result')[0]
 
-    resultFlash.done = cl.createLink(linkForm)
+    resultFlash.done = cl.flashResult(resultFlash, cl.createLink(linkForm))
+    return false
+  }
+
+  cl.flashResult = function(element, action) {
+    return action
       .then(function(message) {
         return { template: 'result success', message: message }
       })
@@ -304,12 +309,11 @@
       .then(function(resultData) {
         var result = cl.getTemplate(resultData.template)
         result.innerHTML = resultData.message
-        return cl.flashElement(resultFlash, result.outerHTML)
+        return cl.flashElement(element, result.outerHTML)
           .then(function() {
-            cl.focusFirstElement(resultFlash, 'a')
+            cl.focusFirstElement(element, 'a')
           })
       })
-    return false
   }
 
   cl.createAnchor = function(url, text) {

--- a/public/app.js
+++ b/public/app.js
@@ -111,7 +111,7 @@
   cl.landingView = function() {
     var view = cl.getTemplate('landing-view'),
         editForm = cl.getTemplate('edit-link'),
-        button = editForm.getElementsByClassName('button')[0]
+        button = editForm.getElementsByTagName('button')[0]
 
     button.onclick = cl.createLinkClick
     view.appendChild(cl.applyData({ submit: 'Create URL' }, editForm))

--- a/public/index.html
+++ b/public/index.html
@@ -55,7 +55,7 @@ body{margin-top:30px;}
         <input class='u-full-width' data-name='url'/>
         <label>Redirect to:</label>
         <input class='u-full-width' data-name='location'/>
-        <button class='button button-primary' data-name='submit'></button>
+        <button class='button-primary' data-name='submit'></button>
         <div class='result'></div>
       </form>
       <div class='result success'>


### PR DESCRIPTION
This is in anticipation of flashing the result of a delete operation inline in the "My links" table.

This also extracts the `prepareFlashingElement` test helper and pared down the number of `createLinkClick` test cases, since the `flashResult` test cases cover every condition at a lower level.

Also removes the 'button' class from button elements. It's redundant and unnecessary, since Skeleton CSS styles the buttons based on tag name to begin with.