### PR TITLE
Extract createLinkInfo and apiErrorMessage, and use preventDefault() in onclick

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -290,12 +290,12 @@
       })
   }
 
-  cl.createLinkClick = function() {
+  cl.createLinkClick = function(e) {
     var linkForm = this.parentNode,
         resultFlash = linkForm.getElementsByClassName('result')[0]
 
     resultFlash.done = cl.flashResult(resultFlash, cl.createLink(linkForm))
-    return false
+    e.preventDefault()
   }
 
   cl.flashResult = function(element, action) {

--- a/public/app.js
+++ b/public/app.js
@@ -30,6 +30,32 @@
     })
   }
 
+  cl.createLinkInfo = function(link) {
+    var url = window.location.origin + '/' + link
+    return {
+      relative: '/' + link,
+      full: url,
+      anchor: '<a href=\'/' + link + '\'>' + url + '</a>'
+    }
+  }
+
+  cl.apiErrorMessage = function(xhrOrErr, linkInfo, prefix) {
+    prefix += ': '
+
+    if (xhrOrErr.status === undefined) {
+      return prefix + (xhrOrErr.message || xhrOrErr)
+    }
+    if (xhrOrErr.status >= 500) {
+      return prefix + 'A server error occurred. ' +
+        'Please contact the system administrator or try again later.'
+    }
+    if (xhrOrErr.response) {
+      return prefix +
+        xhrOrErr.response.err.replace(linkInfo.relative, linkInfo.anchor)
+    }
+    return prefix + xhrOrErr.statusText
+  }
+
   cl.loadApp = function() {
     window.onhashchange = function() {
       cl.showView(window.location.hash)
@@ -248,16 +274,13 @@
   cl.createLink = function(linkForm) {
     var url = linkForm.querySelector('[data-name=url]'),
         location = linkForm.querySelector('[data-name=location]'),
-        resultUrl,
-        resultAnchor
+        linkInfo
 
     if (!url || !location) {
       throw new Error('fields missing from link form: ' + linkForm.outerHTML)
     }
     url = url.value.replace(/^\/+/, '')
     location = location.value
-    resultUrl = window.location.origin + '/' + url
-    resultAnchor = '<a href=\'/' + url + '\'>' + resultUrl + '</a>'
 
     if (url.length === 0) {
       return Promise.reject('Custom link field must not be empty.')
@@ -268,25 +291,14 @@
         'http:// or https://.')
     }
 
+    linkInfo = cl.createLinkInfo(url)
     return cl.xhr('POST', '/api/create/' + url, { location: location })
       .then(function() {
-        return resultAnchor + ' now redirects to ' + location
+        return linkInfo.anchor + ' now redirects to ' + location
       })
-      .catch(function(err) {
-        if (err.status === undefined) {
-          return Promise.reject(err.message || err)
-        }
-        if (err.status >= 500) {
-          return Promise.reject('A server error occurred and ' +
-            resultUrl + ' wasn\'t created. Please contact the system ' +
-            'administrator or try again later.')
-        }
-        if (err.response) {
-          return Promise.reject(err.response.err.replace(
-            '/' + url, resultAnchor))
-        }
-        return Promise.reject('Could not create ' + resultUrl + ': ' +
-          err.statusText)
+      .catch(function(xhrOrErr) {
+        return Promise.reject(cl.apiErrorMessage(xhrOrErr, linkInfo,
+          linkInfo.full + ' wasn\'t created'))
       })
   }
 

--- a/tests/end-to-end/end-to-end.js
+++ b/tests/end-to-end/end-to-end.js
@@ -74,7 +74,7 @@ test.describe('End-to-end test', function() {
     activeElement().sendKeys(Key.ENTER)
     driver.wait(() => {
       return activeElement().getText().then(text => text === url + link)
-    }, 1250, 'timed out waiting for link: ' + link + ' => ' + target)
+    }, 2000, 'timed out waiting for link: ' + link + ' => ' + target)
   }
 
   test.it('creates a new short link', function() {
@@ -84,7 +84,7 @@ test.describe('End-to-end test', function() {
     activeElement().sendKeys(Key.ENTER)
     driver.wait(() => {
       return activeElement().getText().then(text => text === url + 'foo')
-    }, 1250)
+    }, 2000)
     activeElement().click()
     driver.getCurrentUrl().should.become(targetLocation)
   })
@@ -111,7 +111,7 @@ test.describe('End-to-end test', function() {
     driver.wait(() => {
       return activeElement().getText()
         .then(text => text === 'Create a new custom link')
-    }, 250)
+    }, 1000)
     activeElement().click()
     driver.getCurrentUrl().should.become(url)
   })
@@ -126,7 +126,7 @@ test.describe('End-to-end test', function() {
     driver.getCurrentUrl().should.become(url + '#links')
     driver.wait(() => {
       return activeElement().getText().then(text => text === '/bar')
-    }, 1250)
+    }, 2000)
     driver.findElement(By.linkText('/baz'))
     driver.findElement(By.linkText('/foo'))
   })


### PR DESCRIPTION
These functions will be used to implement the upcoming delete API handler.

This change pares down the number of `createLink` test cases, since the `apiErrorMessage` test cases cover every API failure condition at a lower level.

Also, calling `event.preventDefault()`  is apparently more conformant to the DOM Events standard than returning `false`.