### PR TITLE
Handle net::ERR_CONNECTION_REFUSED in XHR and other small fixups

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -298,7 +298,7 @@
       })
       .catch(function(xhrOrErr) {
         return Promise.reject(cl.apiErrorMessage(xhrOrErr, linkInfo,
-          linkInfo.full + ' wasn\'t created'))
+          'The link wasn\'t created'))
       })
   }
 

--- a/public/app.js
+++ b/public/app.js
@@ -24,7 +24,7 @@
       }
       r.onerror = function() {
         reject(new Error('A network error occurred. Please check your ' +
-          'connection or contact the system administator, then try again.'))
+          'connection or contact the system administrator, then try again.'))
       }
       r.send(body)
     })

--- a/public/app.js
+++ b/public/app.js
@@ -19,7 +19,13 @@
 
       r.onreadystatechange = function() {
         if (this.readyState === 4) {
-          this.status >= 200 && this.status < 300 ? resolve(r) : reject(r)
+          if (this.status === 0) {
+            this.onerror()
+          } else if (this.status >= 200 && this.status < 300) {
+            resolve(r)
+          } else {
+            reject(r)
+          }
         }
       }
       r.onerror = function() {

--- a/public/app.js
+++ b/public/app.js
@@ -31,11 +31,13 @@
   }
 
   cl.createLinkInfo = function(link) {
-    var url = window.location.origin + '/' + link
+    var trimmed = link.replace(/^\/+/, ''),
+        url = window.location.origin + '/' + trimmed
+
     return {
-      relative: '/' + link,
+      relative: '/' + trimmed,
       full: url,
-      anchor: '<a href=\'/' + link + '\'>' + url + '</a>'
+      anchor: '<a href=\'/' + trimmed + '\'>' + url + '</a>'
     }
   }
 

--- a/public/app.js
+++ b/public/app.js
@@ -142,7 +142,7 @@
         button = editForm.getElementsByTagName('button')[0]
 
     button.onclick = cl.createLinkClick
-    view.appendChild(cl.applyData({ submit: 'Create URL' }, editForm))
+    view.appendChild(cl.applyData({ submit: 'Create link' }, editForm))
     return Promise.resolve({
       element: view,
       done: function() {

--- a/public/index.html
+++ b/public/index.html
@@ -53,7 +53,7 @@ body{margin-top:30px;}
       <form class='edit-link'>
         <label>Custom link:</label>
         <input class='u-full-width' data-name='url'/>
-        <label>Redirect to:</label>
+        <label>Target URL:</label>
         <input class='u-full-width' data-name='location'/>
         <button class='button-primary' data-name='submit'></button>
         <div class='result'></div>

--- a/public/tests/tests.js
+++ b/public/tests/tests.js
@@ -349,12 +349,19 @@ describe('Custom Links', function() {
 
   describe('createLinkInfo', function() {
     it('returns an object with the relative URL, full URL, anchor', function() {
-      var full = window.location.origin + '/foo'
-      cl.createLinkInfo('foo').should.eql({
-        relative: '/foo',
-        full: full,
-        anchor: '<a href=\'/foo\'>' + full + '</a>'
-      })
+      var full = window.location.origin + '/foo',
+          result = cl.createLinkInfo('foo')
+      result.relative.should.equal('/foo')
+      result.full.should.equal(full)
+      result.anchor.should.equal('<a href=\'/foo\'>' + full + '</a>')
+    })
+
+    it('handles a link that already has a leading slash', function() {
+      var full = window.location.origin + '/foo',
+          result = cl.createLinkInfo('/foo')
+      result.relative.should.equal('/foo')
+      result.full.should.equal(full)
+      result.anchor.should.equal('<a href=\'/foo\'>' + full + '</a>')
     })
   })
 

--- a/public/tests/tests.js
+++ b/public/tests/tests.js
@@ -215,9 +215,9 @@ describe('Custom Links', function() {
 
         expect(labels[0].textContent).to.eql('Custom link:')
         expect(inputs[0]).not.to.eql(null)
-        expect(labels[1].textContent).to.eql('Redirect to:')
+        expect(labels[1].textContent).to.eql('Target URL:')
         expect(inputs[1]).not.to.eql(null)
-        expect(button.textContent).to.contain('Create URL')
+        expect(button.textContent).to.contain('Create link')
         expect(viewElementReceivesFocus(view, inputs[0])).to.equal(true)
       })
     })


### PR DESCRIPTION
As it turns out, the `XMLHttpRequest.onerror` handler won't handle `net::ERR_CONNECTION_REFUSED` or other network errors. For that, one needs to check for `xhr.status === 0` after `xhr.readyState === 4`.

The problem manifest when manually testing to simulate a link deletion request failure by killing the server, and there was no accompanying error message as expected from the `onerror` handler. The hint for the solution came from:

https://stackoverflow.com/questions/28556398/how-to-catch-neterr-connection-refused

This PR also contains commits for:

* Trimming leading slashes in createLinkInfo, as leading slashes from the "My links" table were causing problems.
* Removing the link from the "New link" form's failure message prefix, as it proved actually kind of clunky, especially when the error message itself contained the link text.
* Fixing typo in the XHR network error message
* Updating the "New link" label and button text to try making the actual behavior a bit more clear.