### PR TITLE
public: Minor style touch-ups

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,11 +11,11 @@ body{margin-top:30px;}
 .templates{display:none;}
 .nav{text-align:right;}
 .result{padding:5px;border-radius:5px;}
-.result.success{background-color:whitesmoke;}
-.result.failure{background-color:lavenderblush;}
+.result.success{background-color:whitesmoke;width:100%;text-align:center;}
+.result.failure{background-color:lavenderblush;width:100%;text-align:center;}
 .links-row{display:flex;justify-content:space-between}
 .links-header{font-weight:bold;background-color:whitesmoke;border-radius:5px;}
-.links-data{border-bottom: 2px solid whitesmoke}
+.links-data{border-bottom:2px solid whitesmoke}
 .links .cell{padding:2px}
 .link-target{overflow:hidden;}
 .link-target .cell{word-break:break-all;}
@@ -88,8 +88,8 @@ body{margin-top:30px;}
         <div class='wrapper clicks-action'>
           <div class='cell clicks'></div>
           <div class='cell action'>
-            <button class='button'>Edit</button>
-            <button class='button'>Delete</button>
+            <button>Edit</button>
+            <button>Delete</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
The result success/failure divs now take up 100% of their parent's width and contain center-aligned text.

The removal of the `button` classes should've been included in 560aad5 from #97.