### PR TITLE
Add View and Backend classes

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -109,11 +109,13 @@
 
       replacement.appendChild(view.element)
       container.parentNode.replaceChild(replacement, container)
-
-      if (view.done) {
-        return view.done()
-      }
+      view.done()
     })
+  }
+
+  cl.View = function(element, done) {
+    this.element = element
+    this.done = done || function() { }
   }
 
   cl.getTemplate = function(templateName) {
@@ -151,12 +153,9 @@
 
     button.onclick = cl.createLinkClick
     view.appendChild(cl.applyData({ submit: 'Create link' }, editForm))
-    return Promise.resolve({
-      element: view,
-      done: function() {
-        cl.focusFirstElement(view, 'input')
-      }
-    })
+    return Promise.resolve(new cl.View(view, function() {
+      cl.focusFirstElement(view, 'input')
+    }))
   }
 
   cl.linksView = function() {
@@ -197,12 +196,9 @@
         linksView.appendChild(errMessage)
       })
       .then(function() {
-        return {
-          element: linksView,
-          done: function() {
-            cl.focusFirstElement(linksView, 'a')
-          }
-        }
+        return new cl.View(linksView, function() {
+          cl.focusFirstElement(linksView, 'a')
+        })
       })
   }
 

--- a/public/app.js
+++ b/public/app.js
@@ -77,6 +77,9 @@
   }
 
   cl.Backend.prototype.getUserInfo = function(userId) {
+    if (userId === cl.UNKNOWN_USER) {
+      return Promise.resolve({})
+    }
     return this.xhr('GET', '/api/user/' + userId)
       .catch(function(err) {
         throw new Error('Request for user info failed: ' +
@@ -119,11 +122,8 @@
       js.src = 'vendor/es6-promise.auto.min.js'
       head.appendChild(js)
     }
-    cl.userId = cl.xhr('GET', '/id')
-      .then(function(xhr) { return xhr.response })
-      .catch(function() { return cl.UNKNOWN_USER })
-
-    return cl.userId.then(function(id) {
+    return cl.backend.getLoggedInUserId().then(function(id) {
+      cl.userId = id
       document.getElementById('userid').textContent = id
       return cl.showView(window.location.hash)
     })
@@ -200,33 +200,12 @@
   }
 
   cl.linksView = function() {
-    var linksView = cl.getTemplate('link-view')
-
-    return cl.userId
-      .then(function(uid) {
-        if (uid === cl.UNKNOWN_USER) {
-          return { response: '{}' }
-        }
-        return cl.xhr('GET', '/api/user/' + uid).catch(function(err) {
-          throw new Error('Request for user info failed: ' +
-            (err.message || err.statusText))
-        })
-      })
-      .then(function(result) {
-        var response
-
-        try {
-          response = JSON.parse(result.response)
-        } catch (err) {
-          console.error('Bad user info response:', result.response)
-          throw new Error('Failed to parse user info response: ' +
-            err.message + '<br/>See console messages for details.')
-        }
-
+    return cl.backend.getUserInfo(cl.userId)
+      .then(function(response) {
         if (response.urls === undefined || response.urls.length === 0) {
-          linksView.appendChild(cl.getTemplate('no-links'))
+          return cl.getTemplate('no-links')
         } else {
-          linksView.appendChild(cl.createLinksTable(response.urls))
+          return cl.createLinksTable(response.urls)
         }
       })
       .catch(function(err) {
@@ -234,9 +213,12 @@
 
         console.error(err)
         errMessage.innerHTML = err.message
-        linksView.appendChild(errMessage)
+        return errMessage
       })
-      .then(function() {
+      .then(function(resultElement) {
+        var linksView = cl.getTemplate('link-view')
+
+        linksView.appendChild(resultElement)
         return new cl.View(linksView, function() {
           cl.focusFirstElement(linksView, 'a')
         })
@@ -320,8 +302,7 @@
 
   cl.createLink = function(linkForm) {
     var url = linkForm.querySelector('[data-name=url]'),
-        location = linkForm.querySelector('[data-name=location]'),
-        linkInfo
+        location = linkForm.querySelector('[data-name=location]')
 
     if (!url || !location) {
       throw new Error('fields missing from link form: ' + linkForm.outerHTML)
@@ -337,16 +318,7 @@
       return Promise.reject('Redirect location protocol must be ' +
         'http:// or https://.')
     }
-
-    linkInfo = cl.createLinkInfo(url)
-    return cl.xhr('POST', '/api/create/' + url, { location: location })
-      .then(function() {
-        return linkInfo.anchor + ' now redirects to ' + location
-      })
-      .catch(function(xhrOrErr) {
-        return Promise.reject(cl.apiErrorMessage(xhrOrErr, linkInfo,
-          'The link wasn\'t created'))
-      })
+    return cl.backend.createLink(url, location)
   }
 
   cl.createLinkClick = function(e) {

--- a/public/tests/tests.js
+++ b/public/tests/tests.js
@@ -13,10 +13,6 @@ describe('Custom Links', function() {
       HOST_PREFIX = window.location.protocol + '//' + window.location.host,
       REDIRECT_LOCATION = 'https://mike-bland.com/'
 
-  beforeEach(function() {
-    stubOut('xhr')
-  })
-
   afterEach(function() {
     doubles.forEach(function(double) {
       double.restore()
@@ -29,8 +25,8 @@ describe('Custom Links', function() {
     return spy
   }
 
-  stubOut = function(functionName) {
-    var stub = sinon.stub(cl, functionName)
+  stubOut = function(obj, functionName) {
+    var stub = sinon.stub(obj, functionName)
     doubles.push(stub)
     return stub
   }
@@ -48,7 +44,7 @@ describe('Custom Links', function() {
 
     // Stub cl.fade() instead of cl.flashElement() because we depend upon
     // the result's innerHTML to be set by the latter.
-    stubOut('fade').callsFake(function(element, increment) {
+    stubOut(cl, 'fade').callsFake(function(element, increment) {
       element.style.opacity = increment < 0.0 ? 0 : 1
       return Promise.resolve(element)
     })
@@ -101,7 +97,7 @@ describe('Custom Links', function() {
       var landingView = cl.landingView,
           doneSpy
 
-      stubOut('landingView').callsFake(function() {
+      stubOut(cl, 'landingView').callsFake(function() {
         return landingView().then(function(view) {
           doneSpy = sinon.spy(view, 'done')
           return view
@@ -147,11 +143,8 @@ describe('Custom Links', function() {
     })
 
     describe('getUserInfo', function() {
-      var errorLog
-
       beforeEach(function() {
-        errorLog = sinon.stub(console, 'error')
-        doubles.push(errorLog)
+        stubOut(console, 'error')
       })
 
       it('returns user info from a successful response', function() {
@@ -165,6 +158,10 @@ describe('Custom Links', function() {
           Promise.resolve({ response: JSON.stringify({ urls: usersUrls }) }))
         return backend.getUserInfo('mbland@acm.org')
           .should.become({ urls: usersUrls })
+      })
+
+      it('returns an empty response for cl.UNKNOWN_USER', function() {
+        return backend.getUserInfo(cl.UNKNOWN_USER).should.become({})
       })
 
       it('rejects with an error message', function() {
@@ -187,7 +184,8 @@ describe('Custom Links', function() {
         return backend.getUserInfo('mbland@acm.org')
           .should.be.rejectedWith('Failed to parse user info response: ')
           .then(function() {
-            errorLog.args[0].should.eql(['Bad user info response:', 'foobar'])
+            console.error.args[0].should.eql(
+              ['Bad user info response:', 'foobar'])
           })
       })
     })
@@ -217,8 +215,8 @@ describe('Custom Links', function() {
     var invokeLoadApp
 
     beforeEach(function() {
-      cl.xhr.withArgs('GET', '/id').returns(
-        Promise.resolve({ response: 'mbland@acm.org' }))
+      stubOut(cl.backend, 'getLoggedInUserId')
+      cl.backend.getLoggedInUserId.returns(Promise.resolve('mbland@acm.org'))
     })
 
     invokeLoadApp = function() {
@@ -247,6 +245,12 @@ describe('Custom Links', function() {
       })
     })
 
+    it('sets the logged in user ID', function() {
+      return invokeLoadApp().then(function() {
+        cl.userId.should.equal('mbland@acm.org')
+      })
+    })
+
     it('shows the nav bar', function() {
       return invokeLoadApp().then(function() {
         var navBar,
@@ -265,15 +269,6 @@ describe('Custom Links', function() {
         navLinks[0].href.should.equal(HOST_PREFIX + '/#')
         navLinks[1].href.should.equal(HOST_PREFIX + '/#links')
         navLinks[2].href.should.equal(HOST_PREFIX + '/logout')
-      })
-    })
-
-    it('shows an unknown user marker on /id error', function() {
-      cl.xhr.withArgs('GET', '/id').returns(
-        Promise.reject({ status: 404, response: 'forced error' }))
-      return invokeLoadApp().then(function() {
-        document.getElementById('userid').textContent
-          .should.equal(cl.UNKNOWN_USER)
       })
     })
   })
@@ -419,7 +414,7 @@ describe('Custom Links', function() {
     it('fades an element out, updates its text, and fades it back', function() {
       var replacement = '<p>Goodbye, World!</p>'
 
-      stubOut('fade')
+      stubOut(cl, 'fade')
       cl.fade.callsFake(function(element) {
         return Promise.resolve(element)
       })
@@ -543,45 +538,34 @@ describe('Custom Links', function() {
   })
 
   describe('createLink', function() {
-    var linkForm, expectXhr, linkInfo
+    var linkForm, expectBackendCall
 
     beforeEach(function() {
+      stubOut(cl.backend, 'createLink')
       linkForm = cl.getTemplate('edit-link')
       linkForm.querySelector('[data-name=url]').value = 'foo'
       linkForm.querySelector('[data-name=location]').value = REDIRECT_LOCATION
-      linkInfo = cl.createLinkInfo('foo')
     })
 
-    expectXhr = function() {
-      var payload = { location: REDIRECT_LOCATION }
-      return cl.xhr.withArgs('POST', '/api/create/foo', payload)
+    expectBackendCall = function() {
+      return cl.backend.createLink.withArgs('foo', REDIRECT_LOCATION)
     }
 
-    it('creates a link that doesn\'t already exist', function() {
-      expectXhr().returns(Promise.resolve())
-      return cl.createLink(linkForm).should.become(
-        linkInfo.anchor + ' now redirects to ' + REDIRECT_LOCATION)
+    it('creates a link from valid form data', function() {
+      expectBackendCall().returns(Promise.resolve('backend call succeeded'))
+      return cl.createLink(linkForm).should.become('backend call succeeded')
     })
 
-    it('fails to create a link that already exists', function() {
-      expectXhr().callsFake(function() {
-        return Promise.reject({
-          status: 403,
-          response: { err: '/foo already exists' }
-        })
-      })
+    it('fails to create a link from valid form data', function() {
+      expectBackendCall().returns(Promise.reject('backend call failed'))
       return cl.createLink(linkForm)
-        .should.be.rejectedWith(new RegExp(linkInfo.anchor + ' already exists'))
+        .should.be.rejectedWith('backend call failed')
     })
 
     it('strips leading slashes from the link name', function() {
-      var payload = { location: REDIRECT_LOCATION }
-      cl.xhr.withArgs('POST', '/api/create/foo', payload)
-        .returns(Promise.resolve())
-
+      expectBackendCall().returns(Promise.resolve('backend call succeeded'))
       linkForm.querySelector('[data-name=url]').value = '///foo'
-      return cl.createLink(linkForm).should.become(
-        linkInfo.anchor + ' now redirects to ' + REDIRECT_LOCATION)
+      return cl.createLink(linkForm).should.become('backend call succeeded')
     })
 
     it('throws an error if the custom link field is missing', function() {
@@ -591,7 +575,7 @@ describe('Custom Links', function() {
         'fields missing from link form: ' + linkForm.outerHTML)
     })
 
-    it('throws an error if the redirect location field is missing', function() {
+    it('throws an error if the target URL field is missing', function() {
       var locationField = linkForm.querySelector('[data-name=location]')
       locationField.parentNode.removeChild(locationField)
       expect(function() { cl.createLink(linkForm) }).to.throw(Error,
@@ -604,13 +588,13 @@ describe('Custom Links', function() {
         'Custom link field must not be empty.')
     })
 
-    it('rejects if the redirect location value is missing', function() {
+    it('rejects if the target URL value is missing', function() {
       linkForm.querySelector('[data-name=location]').value = ''
       return cl.createLink(linkForm).should.be.rejectedWith(
         'Redirect location field must not be empty.')
     })
 
-    it('rejects if the location has an incorrect protocol', function() {
+    it('rejects if the target URL has an incorrect protocol', function() {
       linkForm.querySelector('[data-name=location]').value = 'gopher://bar'
       return cl.createLink(linkForm).should.be.rejectedWith(
         'Redirect location protocol must be http:// or https://.')
@@ -684,7 +668,7 @@ describe('Custom Links', function() {
     })
 
     it('flashes result after API call', function() {
-      stubOut('createLink')
+      stubOut(cl, 'createLink')
         .returns(Promise.resolve('<a href="/foo">success</a>'))
       button.click()
       return result.done.should.be.fulfilled.then(function() {
@@ -775,13 +759,12 @@ describe('Custom Links', function() {
   describe('linksView', function() {
     var origUserId = cl.userId,
         userId = 'mbland@acm.org',
-        errorLog,
         setApiResponseLinks
 
     beforeEach(function() {
-      cl.userId = Promise.resolve(userId)
-      errorLog = sinon.stub(console, 'error')
-      doubles.push(errorLog)
+      cl.userId = userId
+      stubOut(console, 'error')
+      stubOut(cl.backend, 'getUserInfo')
     })
 
     afterEach(function() {
@@ -789,8 +772,8 @@ describe('Custom Links', function() {
     })
 
     setApiResponseLinks = function(links) {
-      cl.xhr.withArgs('GET', '/api/user/' + userId).returns(
-        Promise.resolve({ response: JSON.stringify({ urls: links }) }))
+      cl.backend.getUserInfo.withArgs(userId)
+        .returns(Promise.resolve({ urls: links }))
     }
 
     it('shows no links for a valid user', function() {
@@ -807,8 +790,8 @@ describe('Custom Links', function() {
     })
 
     it('shows no links for cl.UNKNOWN_USER', function() {
-      setApiResponseLinks([{ url: 'bogus', location: 'should not appear' }])
-      cl.userId = Promise.resolve(cl.UNKNOWN_USER)
+      cl.userId = cl.UNKNOWN_USER
+      cl.backend.getUserInfo.callThrough()
       return cl.linksView().then(function(view) {
         expect(view.element.getElementsByClassName('no-links')[0])
           .to.not.be.undefined
@@ -840,60 +823,25 @@ describe('Custom Links', function() {
       })
     })
 
-    it('shows a network error message', function() {
-      cl.xhr.withArgs('GET', '/api/user/' + userId).returns(
+    it('shows an error message when the backend call fails', function() {
+      cl.backend.getUserInfo.withArgs(userId).returns(
         Promise.reject(new Error('simulated network error')))
 
       return cl.linksView().then(function(view) {
-        var errorMsg = view.element.getElementsByClassName('result failure')[0],
-            expected = 'Request for user info failed: simulated network error'
+        var errorMsg = view.element.getElementsByClassName('result failure')[0]
 
         expect(errorMsg).to.not.be.undefined
-        errorMsg.textContent.should.equal(expected)
-        errorLog.args[0][0].message.should.equal(expected)
-      })
-    })
-
-    it('shows an XmlHttpRequest error status message', function() {
-      cl.xhr.withArgs('GET', '/api/user/' + userId).returns(
-        Promise.reject({ statusText: 'simulated response failure' }))
-
-      return cl.linksView().then(function(view) {
-        var errorMsg = view.element.getElementsByClassName('result failure')[0],
-            expected = 'Request for user info failed: ' +
-              'simulated response failure'
-
-        expect(errorMsg).to.not.be.undefined
-        errorMsg.textContent.should.equal(expected)
-        errorLog.args[0][0].message.should.equal(expected)
-      })
-    })
-
-    it('shows a JSON parsing error message from the API response', function() {
-      var badResponse = JSON.stringify({ urls: [] }) + 'foobar'
-
-      cl.xhr.withArgs('GET', '/api/user/' + userId).returns(
-        Promise.resolve({ response: badResponse }))
-
-      return cl.linksView().then(function(view) {
-        var errorMsg = view.element.getElementsByClassName('result failure')[0],
-            expected = /Failed to parse user info response:/
-
-        expect(errorMsg).to.not.be.undefined
-        errorMsg.textContent.should.match(expected)
-        errorLog.args[0][0].should.equal('Bad user info response:')
-        errorLog.args[0][1].should.equal(badResponse)
-        errorLog.args[1][0].message.should.match(expected)
+        errorMsg.textContent.should.equal('simulated network error')
+        console.error.args[0][0].message.should.equal('simulated network error')
       })
     })
   })
 
   describe('Dialog', function() {
-    var dialog, errorLog, errPrefix, addTemplate, testTemplate, event
+    var dialog, errPrefix, addTemplate, testTemplate, event
 
     beforeEach(function() {
-      errorLog = sinon.stub(console, 'error')
-      doubles.push(errorLog)
+      stubOut(console, 'error')
       errPrefix = 'The "test-template" dialog box template '
       testTemplate = addTemplate('test-template', [
         '<div class=\'test-dialog dialog\'>',

--- a/tests/end-to-end/end-to-end.js
+++ b/tests/end-to-end/end-to-end.js
@@ -74,7 +74,7 @@ test.describe('End-to-end test', function() {
     activeElement().sendKeys(Key.ENTER)
     driver.wait(() => {
       return activeElement().getText().then(text => text === url + link)
-    }, 2000, 'timed out waiting for link: ' + link + ' => ' + target)
+    }, 3000, 'timed out waiting for link: ' + link + ' => ' + target)
   }
 
   test.it('creates a new short link', function() {
@@ -84,7 +84,7 @@ test.describe('End-to-end test', function() {
     activeElement().sendKeys(Key.ENTER)
     driver.wait(() => {
       return activeElement().getText().then(text => text === url + 'foo')
-    }, 2000)
+    }, 3000)
     activeElement().click()
     driver.getCurrentUrl().should.become(targetLocation)
   })
@@ -111,7 +111,7 @@ test.describe('End-to-end test', function() {
     driver.wait(() => {
       return activeElement().getText()
         .then(text => text === 'Create a new custom link')
-    }, 1000)
+    }, 3000)
     activeElement().click()
     driver.getCurrentUrl().should.become(url)
   })
@@ -126,7 +126,7 @@ test.describe('End-to-end test', function() {
     driver.getCurrentUrl().should.become(url + '#links')
     driver.wait(() => {
       return activeElement().getText().then(text => text === '/bar')
-    }, 2000)
+    }, 3000)
     driver.findElement(By.linkText('/baz'))
     driver.findElement(By.linkText('/foo'))
   })


### PR DESCRIPTION
The `View` class makes the object expected by `showView` a bit more self-documenting.

The `Backend` class encapsulates all the details of API requests and response handling so that the user interface functions don't need to manage them any longer.

Replacing calls to `cl.xhr` with calls to `cl.backend` was a case where having the end-to-end tests paid off; it caught the fact that `cl.userId` wasn't getting set properly after getting all of the browser-only tests to pass.