### PR TITLE
Apply data in Dialog constructor

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -347,7 +347,7 @@
       })
   }
 
-  cl.Dialog = function(templateName, resultElement, startOperation) {
+  cl.Dialog = function(templateName, data, startOperation, resultElement) {
     var dialog = this,
         errPrefix = 'The "' + templateName + '" dialog box template '
 
@@ -376,6 +376,7 @@
 
     this.first = this.buttons[0]
     this.last = this.buttons[this.buttons.length - 1]
+    cl.applyData(data, this.box)
     this.element = cl.getTemplate('dialog-overlay')
     this.element.appendChild(this.box)
     this.previousFocus = document.activeElement

--- a/public/tests/tests.js
+++ b/public/tests/tests.js
@@ -847,15 +847,17 @@ describe('Custom Links', function() {
       testTemplate = addTemplate('test-template', [
         '<div class=\'test-dialog dialog\'>',
         '  <h3 class=\'title\'>Confirm update</h3>',
-        '  <p class=\'description\'>Update <span class=\'link\'></span>?</p>',
+        '  <p class=\'description\'>',
+        '    Update <span data-name=\'link\'></span>?',
+        '  </p>',
         '  <button class=\'confirm focused\'>OK</button>',
         '  <button class=\'cancel\'>Cancel</button>',
         '</div>'
       ].join('\n'))
 
-      dialog = new cl.Dialog('test-template', resultElement, function() {
+      dialog = new cl.Dialog('test-template', { link: '/foo' }, function() {
         return Promise.resolve('operation done')
-      })
+      }, resultElement)
       event = {
         keyCode: null,
         shiftKey: false,
@@ -886,9 +888,15 @@ describe('Custom Links', function() {
     }
 
     it('creates an object from a valid dialog box template', function() {
+      var link
+
       expect(dialog.element).to.not.be.undefined
       expect(dialog.element.parentNode).to.be.null
       expect(dialog.previousFocus).to.equal(document.activeElement)
+
+      link = dialog.element.querySelector(['[data-name=link]'])
+      expect(link).to.not.be.undefined
+      expect(link.textContent).to.equal('/foo')
     })
 
     it('throws if the template doesn\'t contain a title', function() {
@@ -952,7 +960,7 @@ describe('Custom Links', function() {
       cancel = testTemplate.getElementsByClassName('cancel')[0]
       expect(cancel).to.equal(confirm)
 
-      dialog = new cl.Dialog('test-template', null, operation)
+      dialog = new cl.Dialog('test-template', {}, operation)
       spyOn(dialog, 'close')
       dialog.confirm.click()
       operation.called.should.be.false

--- a/public/tests/tests.js
+++ b/public/tests/tests.js
@@ -19,8 +19,8 @@ describe('Custom Links', function() {
     })
   })
 
-  spyOn = function(functionName) {
-    var spy = sinon.spy(cl, functionName)
+  spyOn = function(obj, functionName) {
+    var spy = sinon.spy(obj, functionName)
     doubles.push(spy)
     return spy
   }
@@ -87,7 +87,7 @@ describe('Custom Links', function() {
     })
 
     it('passes the hash view parameter to the view function', function() {
-      spyOn('landingView')
+      spyOn(cl, 'landingView')
       return cl.showView('#-foo-bar').then(function() {
         cl.landingView.calledWith('foo-bar').should.be.true
       })
@@ -230,7 +230,7 @@ describe('Custom Links', function() {
     }
 
     it('invokes the router when loaded', function() {
-      spyOn('showView')
+      spyOn(cl, 'showView')
       return invokeLoadApp().then(function() {
         cl.showView.calledWith(window.location.hash).should.be.true
       })
@@ -239,7 +239,7 @@ describe('Custom Links', function() {
     it('subscribes to the hashchange event', function() {
       return invokeLoadApp().then(function(hashChangeHandler) {
         expect(typeof hashChangeHandler).to.equal('function')
-        spyOn('showView')
+        spyOn(cl, 'showView')
         hashChangeHandler()
         cl.showView.calledWith(window.location.hash).should.be.true
       })
@@ -940,6 +940,23 @@ describe('Custom Links', function() {
       clTest.removeElement(cancel)
       expect(function() { return new cl.Dialog('test-template') })
         .to.throw(errPrefix + 'doesn\'t define a cancel button.')
+    })
+
+    it('overrides confirm with cancel behavior for single button', function() {
+      var confirm = testTemplate.getElementsByClassName('confirm')[0],
+          cancel = testTemplate.getElementsByClassName('cancel')[0],
+          operation = sinon.spy()
+
+      clTest.removeElement(cancel)
+      confirm.className += ' cancel'
+      cancel = testTemplate.getElementsByClassName('cancel')[0]
+      expect(cancel).to.equal(confirm)
+
+      dialog = new cl.Dialog('test-template', null, operation)
+      spyOn(dialog, 'close')
+      dialog.confirm.click()
+      operation.called.should.be.false
+      dialog.close.called.should.be.true
     })
 
     it('sets role and ARIA attributes on open', function() {


### PR DESCRIPTION
In addition to adding a `data` parameter so that templates can specify variable elements with the `data-name` attribute, this change reorders the constructor arguments to the `resultElement` comes last. Possibly makes formating calls a bit more awkward, but semantically makes more sense to supply the template name, the template data, the operation callback, and the result flash element in that order.

Adds a test to codify existing behavior whereby a Dialog may be created with a single button with a class attribute of 'confirm cancel focused'.