### PR TITLE
e2e: Eliminate flakiness using webdriver.until

### DIFF
--- a/tests/end-to-end/end-to-end.js
+++ b/tests/end-to-end/end-to-end.js
@@ -9,6 +9,7 @@ var test = require('selenium-webdriver/testing')
 var webdriver = require('selenium-webdriver')
 var By = webdriver.By
 var Key = webdriver.Key
+var until = webdriver.until
 
 chai.should()
 chai.use(chaiAsPromised)
@@ -20,7 +21,8 @@ test.describe('End-to-end test', function() {
       url,
       targetLocation,
       activeElement,
-      createNewLink
+      createNewLink,
+      waitForActiveLink
 
   // eslint-disable-next-line no-unused-vars
   var takeScreenshot
@@ -65,16 +67,23 @@ test.describe('End-to-end test', function() {
 
   createNewLink = (link, target) => {
     driver.findElement(By.linkText('New link')).click()
-    driver.getCurrentUrl().should.become(url + '#')
+    driver.wait(until.urlIs(url + '#'))
     driver.findElement(By.tagName('input')).click()
     activeElement().sendKeys(
       Key.HOME, Key.chord(Key.SHIFT, Key.END), link + Key.TAB)
     activeElement().sendKeys(
       Key.HOME, Key.chord(Key.SHIFT, Key.END), target + Key.TAB)
     activeElement().sendKeys(Key.ENTER)
-    driver.wait(() => {
-      return activeElement().getText().then(text => text === url + link)
-    }, 3000, 'timed out waiting for link: ' + link + ' => ' + target)
+    waitForActiveLink(url + link)
+  }
+
+  waitForActiveLink = (linkText) => {
+    var link = driver.wait(until.elementLocated(By.linkText(linkText)), 2000,
+      'timeout waiting for "' + linkText + '" link to appear')
+
+    driver.wait(() => webdriver.WebElement.equals(activeElement(), link), 2000,
+      'timeout waiting for "' + linkText + '" link to become active')
+    return link
   }
 
   test.it('creates a new short link', function() {
@@ -82,11 +91,8 @@ test.describe('End-to-end test', function() {
     activeElement().sendKeys('foo' + Key.TAB)
     activeElement().sendKeys(targetLocation + Key.TAB)
     activeElement().sendKeys(Key.ENTER)
-    driver.wait(() => {
-      return activeElement().getText().then(text => text === url + 'foo')
-    }, 3000)
-    activeElement().click()
-    driver.getCurrentUrl().should.become(targetLocation)
+    waitForActiveLink(url + 'foo').click()
+    driver.wait(until.urlIs(targetLocation))
   })
 
   test.it('logs out of the application', function() {
@@ -97,7 +103,7 @@ test.describe('End-to-end test', function() {
     activeElement().click()
     // Note that since we're using the dummy test auth instance, we'll get
     // redirected back to the landing page.
-    driver.getCurrentUrl().should.become(url)
+    driver.wait(until.urlIs(url))
   })
 
   test.it('shows the no-links message before any links created', function() {
@@ -107,26 +113,20 @@ test.describe('End-to-end test', function() {
     activeElement().getText().should.become('My links')
     activeElement().click()
 
-    driver.getCurrentUrl().should.become(url + '#links')
-    driver.wait(() => {
-      return activeElement().getText()
-        .then(text => text === 'Create a new custom link')
-    }, 3000)
-    activeElement().click()
-    driver.getCurrentUrl().should.become(url)
+    driver.wait(until.urlIs(url + '#links'))
+    waitForActiveLink('Create a new custom link').click()
+    driver.wait(until.urlIs(url))
   })
 
   test.it('shows user\'s links on the "My links" page', function() {
     this.timeout(10000)
-    createNewLink('foo', 'https://foo.com')
-    createNewLink('baz', 'https://baz.com')
-    createNewLink('bar', 'https://bar.com')
+    createNewLink('foo', targetLocation)
+    createNewLink('baz', targetLocation)
+    createNewLink('bar', targetLocation)
 
     driver.findElement(By.linkText('My links')).click()
-    driver.getCurrentUrl().should.become(url + '#links')
-    driver.wait(() => {
-      return activeElement().getText().then(text => text === '/bar')
-    }, 3000)
+    driver.wait(until.urlIs(url + '#links'))
+    waitForActiveLink('/bar')
     driver.findElement(By.linkText('/baz'))
     driver.findElement(By.linkText('/foo'))
   })

--- a/tests/end-to-end/end-to-end.js
+++ b/tests/end-to-end/end-to-end.js
@@ -42,6 +42,10 @@ test.describe('End-to-end test', function() {
     })
   })
 
+  test.beforeEach(function() {
+    return driver.get(url)
+  })
+
   test.afterEach(function() {
     return new Promise(function(resolve, reject) {
       redisClient.flushdb(err => err ? reject(err) : resolve())
@@ -87,7 +91,6 @@ test.describe('End-to-end test', function() {
   }
 
   test.it('creates a new short link', function() {
-    driver.get(url)
     activeElement().sendKeys('foo' + Key.TAB)
     activeElement().sendKeys(targetLocation + Key.TAB)
     activeElement().sendKeys(Key.ENTER)
@@ -96,7 +99,6 @@ test.describe('End-to-end test', function() {
   })
 
   test.it('logs out of the application', function() {
-    driver.get(url)
     activeElement().sendKeys(Key.chord(Key.SHIFT, Key.TAB))
     activeElement().getText().should.become('Log out')
     activeElement().getAttribute('href').should.become(url + 'logout')
@@ -107,7 +109,6 @@ test.describe('End-to-end test', function() {
   })
 
   test.it('shows the no-links message before any links created', function() {
-    driver.get(url)
     activeElement().sendKeys(Key.chord(Key.SHIFT, Key.TAB))
     activeElement().sendKeys(Key.chord(Key.SHIFT, Key.TAB))
     activeElement().getText().should.become('My links')


### PR DESCRIPTION
The first end-to-end test case ("creates a new short link") was failing rather frequently on Travis CI. This attempts to remove the flakiness by using conditions from `webdriver.until` with `webdriver.wait`, both by waiting for links to appear before waiting for them to receive focus (in `waitForActiveLink`) and by using `until.urlIs` to wait for the URL to change after a click.

Also replaced `https://foo.com/`, etc. with `targetLocation` after noticing that some failing tests caused the actual `http://baz.com` to appear.