### PR TITLE
public: Fill in create link form with unknown link

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -63,7 +63,7 @@ function assembleApp(app, redirectDb, logger, sessionStore, config) {
   app.get('/*', (req, res) => {
     redirectDb.getRedirect(req.path, { recordAccess: true })
       .then(urlData => {
-        res.redirect(urlData !== null ? urlData.location : '/?url=' + req.path)
+        res.redirect(urlData !== null ? urlData.location : '/#-' + req.path)
       })
       .catch(errorHandler(req, res, logger))
   })

--- a/public/app.js
+++ b/public/app.js
@@ -199,15 +199,16 @@
     return element
   }
 
-  cl.landingView = function() {
+  cl.landingView = function(link) {
     var view = cl.getTemplate('landing-view'),
         editForm = cl.getTemplate('edit-link'),
         button = editForm.getElementsByTagName('button')[0]
 
     button.onclick = cl.createLinkClick
-    view.appendChild(cl.applyData({ submit: 'Create link' }, editForm))
+    link = (link || '').replace(/^\/+/, '')
+    view.appendChild(cl.applyData({ url: link }, editForm))
     return Promise.resolve(new cl.View(view, function() {
-      cl.focusFirstElement(view, 'input')
+      view.getElementsByTagName('input')[link ? 1 : 0].focus()
     }))
   }
 

--- a/public/index.html
+++ b/public/index.html
@@ -61,7 +61,7 @@ body{margin-top:30px;}
         <input class='u-full-width' data-name='url'/>
         <label>Target URL:</label>
         <input class='u-full-width' data-name='location'/>
-        <button class='button-primary' data-name='submit'></button>
+        <button class='button-primary' data-name='submit'>Create link</button>
         <div class='result'></div>
       </form>
       <div class='result success'>

--- a/public/tests/tests.js
+++ b/public/tests/tests.js
@@ -88,8 +88,8 @@ describe('Custom Links', function() {
 
     it('passes the hash view parameter to the view function', function() {
       spyOn(cl, 'landingView')
-      return cl.showView('#-foo-bar').then(function() {
-        cl.landingView.calledWith('foo-bar').should.be.true
+      return cl.showView('#-/foo').then(function() {
+        cl.landingView.calledWith('/foo').should.be.true
       })
     })
 
@@ -316,6 +316,17 @@ describe('Custom Links', function() {
         expect(inputs[1]).not.to.eql(null)
         expect(button.textContent).to.contain('Create link')
         expect(viewElementReceivesFocus(view, inputs[0])).to.equal(true)
+      })
+    })
+
+    it('fills in the link field when passed a hash view parameter', function() {
+      return cl.landingView('/foo').then(function(view) {
+        var form = view.element.getElementsByTagName('form').item(0),
+            inputs = form.getElementsByTagName('input')
+
+        expect(inputs[0]).not.to.eql(null)
+        inputs[0].defaultValue.should.equal('foo')
+        expect(viewElementReceivesFocus(view, inputs[1])).to.equal(true)
       })
     })
   })

--- a/tests/end-to-end/end-to-end.js
+++ b/tests/end-to-end/end-to-end.js
@@ -82,10 +82,10 @@ test.describe('End-to-end test', function() {
   }
 
   waitForActiveLink = (linkText) => {
-    var link = driver.wait(until.elementLocated(By.linkText(linkText)), 2000,
+    var link = driver.wait(until.elementLocated(By.linkText(linkText)), 3000,
       'timeout waiting for "' + linkText + '" link to appear')
 
-    driver.wait(() => webdriver.WebElement.equals(activeElement(), link), 2000,
+    driver.wait(() => webdriver.WebElement.equals(activeElement(), link), 3000,
       'timeout waiting for "' + linkText + '" link to become active')
     return link
   }

--- a/tests/end-to-end/end-to-end.js
+++ b/tests/end-to-end/end-to-end.js
@@ -72,7 +72,7 @@ test.describe('End-to-end test', function() {
   createNewLink = (link, target) => {
     driver.findElement(By.linkText('New link')).click()
     driver.wait(until.urlIs(url + '#'))
-    driver.findElement(By.tagName('input')).click()
+    driver.findElement(By.css('input')).click()
     activeElement().sendKeys(
       Key.HOME, Key.chord(Key.SHIFT, Key.END), link + Key.TAB)
     activeElement().sendKeys(
@@ -96,6 +96,16 @@ test.describe('End-to-end test', function() {
     activeElement().sendKeys(Key.ENTER)
     waitForActiveLink(url + 'foo').click()
     driver.wait(until.urlIs(targetLocation))
+  })
+
+  test.it('opens the new link form for an unknown link', function() {
+    driver.get(url + 'foo')
+    driver.wait(until.urlIs(url + '#-/foo'))
+    driver.findElement(By.css('input')).getAttribute('value')
+      .should.become('foo')
+    activeElement().sendKeys(targetLocation + Key.TAB)
+    activeElement().sendKeys(Key.ENTER)
+    waitForActiveLink(url + 'foo')
   })
 
   test.it('logs out of the application', function() {

--- a/tests/server/app-test.js
+++ b/tests/server/app-test.js
@@ -169,7 +169,7 @@ describe('assembleApp', function() {
         .get('/foo')
         .set('cookie', sessionCookie)
         .expect(302)
-        .expect('location', '/?url=/foo')
+        .expect('location', '/#-/foo')
     })
 
     it('reports an error', function() {


### PR DESCRIPTION
When the user attempts to use a nonexistent link, the app will automatically open the create link form with that link filled in so that the user can easily create the new link right away.

The backend required a small tweak to update the hash parameter.