### PR TITLE
Make "My links" the default landing page

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,8 +62,8 @@ function assembleApp(app, linkDb, logger, sessionStore, config) {
 
   app.get('/*', (req, res) => {
     linkDb.getLink(req.path, { recordAccess: true })
-      .then(linkData => {
-        res.redirect(linkData !== null ? linkData.target : '/#-' + req.path)
+      .then(link => {
+        res.redirect(link !== null ? link.target : '/#create-' + req.path)
       })
       .catch(errorHandler(req, res, logger))
   })

--- a/public/app.js
+++ b/public/app.js
@@ -142,12 +142,12 @@
   }
 
   cl.showView = function(hashId) {
-    var viewId = hashId === '' ? '#' : hashId.split('-', 1),
+    var viewId = hashId === '' ? '#' : hashId.split('-', 1)[0],
         viewParam = hashId.slice(viewId.length + 1),
         container = document.getElementsByClassName('view-container')[0],
         routes = {
-          '#': cl.createLinkView,
-          '#links': cl.linksView
+          '#create': cl.createLinkView,
+          '#': cl.linksView
         },
         renderView = routes[viewId]
 

--- a/public/index.html
+++ b/public/index.html
@@ -45,8 +45,8 @@ body{margin-top:30px;}
     <div class='header container'>
       <div class='nav'>
         <span id='userid'></span> |
-        <a href='/#'>New&nbsp;link</a> |
-        <a href='/#links'>My&nbsp;links</a> |
+        <a href='/#'>My&nbsp;links</a> |
+        <a href='/#create'>New&nbsp;link</a> |
         <a href='/logout'>Log&nbsp;out</a>
       </div>
       <h3>Custom Links</h3>
@@ -96,7 +96,7 @@ body{margin-top:30px;}
       </div>
       <div class='no-links'>
         <p>You do not own any custom links.</p>
-        <p><a href='/'>Create a new custom link</a> now.</p>
+        <p><a href='/#create'>Create a new custom link</a> now.</p>
       </div>
       <div class='dialog-overlay' tabindex='-1'>
       </div>

--- a/tests/end-to-end/end-to-end.js
+++ b/tests/end-to-end/end-to-end.js
@@ -71,7 +71,7 @@ test.describe('End-to-end test', function() {
 
   createNewLink = (link, target) => {
     driver.findElement(By.linkText('New link')).click()
-    driver.wait(until.urlIs(url + '#'))
+    driver.wait(until.urlIs(url + '#create'))
     driver.findElement(By.css('input')).click()
     activeElement().sendKeys(
       Key.HOME, Key.chord(Key.SHIFT, Key.END), link + Key.TAB)
@@ -90,6 +90,13 @@ test.describe('End-to-end test', function() {
     return link
   }
 
+  test.it('shows the no-links message before any links created', function() {
+    activeElement().getText().should.become('Create a new custom link')
+    activeElement().getAttribute('href').should.become(url + '#create')
+    activeElement().click()
+    driver.wait(until.urlIs(url + '#create'))
+  })
+
   test.it('logs out of the application', function() {
     activeElement().sendKeys(Key.chord(Key.SHIFT, Key.TAB))
     activeElement().getText().should.become('Log out')
@@ -100,18 +107,12 @@ test.describe('End-to-end test', function() {
     driver.wait(until.urlIs(url))
   })
 
-  test.it('shows the no-links message before any links created', function() {
-    activeElement().sendKeys(Key.chord(Key.SHIFT, Key.TAB))
-    activeElement().sendKeys(Key.chord(Key.SHIFT, Key.TAB))
-    activeElement().getText().should.become('My links')
-    activeElement().click()
-
-    driver.wait(until.urlIs(url + '#links'))
-    waitForActiveLink('Create a new custom link').click()
-    driver.wait(until.urlIs(url))
-  })
-
   test.it('creates a new short link', function() {
+    activeElement().sendKeys(Key.chord(Key.SHIFT, Key.TAB))
+    activeElement().sendKeys(Key.chord(Key.SHIFT, Key.TAB))
+    activeElement().getText().should.become('New link')
+    activeElement().click()
+    driver.wait(until.urlIs(url + '#create'))
     activeElement().sendKeys('foo' + Key.TAB)
     activeElement().sendKeys(targetLocation + Key.TAB)
     activeElement().sendKeys(Key.ENTER)
@@ -121,7 +122,7 @@ test.describe('End-to-end test', function() {
 
   test.it('opens the new link form for an unknown link', function() {
     driver.get(url + 'foo')
-    driver.wait(until.urlIs(url + '#-/foo'))
+    driver.wait(until.urlIs(url + '#create-/foo'))
     driver.findElement(By.css('input')).getAttribute('value')
       .should.become('foo')
     activeElement().sendKeys(targetLocation + Key.TAB)
@@ -136,7 +137,7 @@ test.describe('End-to-end test', function() {
     createNewLink('bar', targetLocation)
 
     driver.findElement(By.linkText('My links')).click()
-    driver.wait(until.urlIs(url + '#links'))
+    driver.wait(until.urlIs(url + '#'))
     waitForActiveLink('/bar')
     driver.findElement(By.linkText('/baz'))
     driver.findElement(By.linkText('/foo'))
@@ -146,7 +147,7 @@ test.describe('End-to-end test', function() {
   test.it('deletes a link from the "My links" page', function() {
     createNewLink('foo', targetLocation)
     driver.findElement(By.linkText('My links')).click()
-    driver.wait(until.urlIs(url + '#links'))
+    driver.wait(until.urlIs(url + '#'))
 
     // Tab over to the "Delete" button.
     waitForActiveLink('/foo')

--- a/tests/end-to-end/end-to-end.js
+++ b/tests/end-to-end/end-to-end.js
@@ -43,7 +43,8 @@ test.describe('End-to-end test', function() {
   })
 
   test.beforeEach(function() {
-    return driver.get(url)
+    driver.get(url)
+    return waitForActiveLink('Create a new custom link')
   })
 
   test.afterEach(function() {
@@ -91,7 +92,6 @@ test.describe('End-to-end test', function() {
   }
 
   test.it('shows the no-links message before any links created', function() {
-    activeElement().getText().should.become('Create a new custom link')
     activeElement().getAttribute('href').should.become(url + '#create')
     activeElement().click()
     driver.wait(until.urlIs(url + '#create'))
@@ -108,11 +108,14 @@ test.describe('End-to-end test', function() {
   })
 
   test.it('creates a new short link', function() {
+    // Rather than click on the active "Create a new custom link" link, let's
+    // make sure we can navigate to "New link" in the nav bar as expected.
     activeElement().sendKeys(Key.chord(Key.SHIFT, Key.TAB))
     activeElement().sendKeys(Key.chord(Key.SHIFT, Key.TAB))
     activeElement().getText().should.become('New link')
     activeElement().click()
     driver.wait(until.urlIs(url + '#create'))
+
     activeElement().sendKeys('foo' + Key.TAB)
     activeElement().sendKeys(targetLocation + Key.TAB)
     activeElement().sendKeys(Key.ENTER)

--- a/tests/server/app-test.js
+++ b/tests/server/app-test.js
@@ -169,7 +169,7 @@ describe('assembleApp', function() {
         .get('/foo')
         .set('cookie', sessionCookie)
         .expect(302)
-        .expect('location', '/#-/foo')
+        .expect('location', '/#create-/foo')
     })
 
     it('reports an error', function() {


### PR DESCRIPTION
This seems to make more sense, as the anticipated default use case for the root URL is to see a list of existing links owned by the user. This is compounded by the fact that accessing a nonexistent link will automatically open the "New link" view.

Required updating the browser tests such that `cl.userId` is set and `cl.backend.getUserInfo` is stubbed in the top-level `beforeEach`. Took the opportunity to add `USER_ID` everywhere as well.