### PR TITLE
public: Show created, updated timestamps

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -274,17 +274,24 @@
     links.forEach(function(link) {
       var current = linkEntry.cloneNode(true),
           cells = current.getElementsByClassName('cell'),
-          actions = cells[3].getElementsByTagName('button')
+          actions = cells[5].getElementsByTagName('button')
 
       cells[0].appendChild(cl.createAnchor(link.link))
       cells[1].appendChild(cl.createAnchor(link.target))
-      cells[2].textContent = link.count
+      cells[2].textContent = cl.dateStamp(link.created)
+      cells[3].textContent = cl.dateStamp(link.updated)
+      cells[4].textContent = link.count
       actions[1].onclick = function() {
         cl.confirmDelete(link.link, current, linksView).open()
       }
       linkTable.appendChild(current)
     })
     return linkTable
+  }
+
+  cl.dateStamp = function(timestamp) {
+    var date = new Date(timestamp ? parseInt(timestamp) : 0)
+    return date.toLocaleString().replace(/, /, ' ')
   }
 
   cl.fade = function(element, increment, deadline) {

--- a/public/index.html
+++ b/public/index.html
@@ -26,17 +26,17 @@ body{margin-top:30px;}
 .dialog-overlay{position:fixed;top:0;right:0;bottom:0;left:0;background:rgba(0,0,0,0.3);z-index:2;}
 .dialog {width:375px;position:relative;background:whitesmoke;border-radius:5px;margin:20% auto;padding:10px 0;text-align:center;font-weight:bold;border:medium solid black;z-index:3;}
 .dialog .confirm{background:lavenderblush;}
-@media (max-width:749px){
+@media (max-width:849px){
 .clicks-action{flex:0 0;}
 }
-@media (min-width:750px){
+@media (min-width:850px){
+.timestamp.cell{width:100px;word-break:normal;}
 .link-target{display:flex;flex:1;}
-.clicks-action{display:flex;flex:0.5;justify-content:flex-end;}
+.links-header .clicks-action{width:215px;}
 .links .cell{flex:0 0 100px;}
 .links button{margin:2px;}
-.links-header .action{text-align:center;flex:0 0 215px;}
 .links-data .action{display:flex;flex:0 0 215px;}
-.links-row .target{flex:1;}
+.links-row .target{flex:1 1 auto;}
 }
 </style>
 </head>
@@ -74,6 +74,8 @@ body{margin-top:30px;}
           <div class='wrapper link-target'>
             <div class='label cell'>Link</div>
             <div class='label cell target'>Target</div>
+            <div class='label cell timestamp created'>Created</div>
+            <div class='label cell timestamp updated'>Updated</div>
           </div>
           <div class='wrapper clicks-action'>
             <div class='label cell clicks'>Clicks</div>
@@ -85,6 +87,8 @@ body{margin-top:30px;}
         <div class='wrapper link-target'>
           <div class='cell'></div>
           <div class='cell target'></div>
+          <div class='cell timestamp created'></div>
+          <div class='cell timestamp updated'></div>
         </div>
         <div class='wrapper clicks-action'>
           <div class='cell clicks'></div>

--- a/public/tests/tests.js
+++ b/public/tests/tests.js
@@ -744,6 +744,19 @@ describe('Custom Links', function() {
     })
   })
 
+  describe('dateStamp', function() {
+    it('returns a properly formatted locale date string', function() {
+      var date = new Date
+      cl.dateStamp(date.getTime() + '').should.equal(
+        date.toLocaleString().replace(/, /, ' '))
+    })
+
+    it('returns a default date string if timestamp undefined', function() {
+      var date = new Date(0)
+      cl.dateStamp().should.equal(date.toLocaleString().replace(/, /, ' '))
+    })
+  })
+
   describe('createLinksTable', function() {
     var linksView
 
@@ -760,10 +773,17 @@ describe('Custom Links', function() {
     })
 
     it('returns a table with a single element', function() {
-      var links = [{ link: '/foo', target: 'https://foo.com/', count: 3 }],
+      var links = [{
+            link: '/foo',
+            target: 'https://foo.com/',
+            created: '0987654321',
+            updated: '1234567890',
+            count: 3
+          }],
           table = cl.createLinksTable(links, linksView),
           linkRow = table.children[1],
           anchors,
+          timestamps,
           buttons,
           linkTarget,
           clicksAction
@@ -776,6 +796,11 @@ describe('Custom Links', function() {
       anchors[0].href.should.equal(HOST_PREFIX + '/foo')
       anchors[1].textContent.should.equal('https://foo.com/')
       anchors[1].href.should.equal('https://foo.com/')
+
+      timestamps = linkTarget.getElementsByClassName('timestamp')
+      timestamps.length.should.equal(2)
+      timestamps[0].textContent.should.equal(cl.dateStamp('0987654321'))
+      timestamps[1].textContent.should.equal(cl.dateStamp('1234567890'))
 
       clicksAction = linkRow.children[1]
       clicksAction.children.length.should.equal(2)


### PR DESCRIPTION
This seems like generally useful information. A future change will make the links table sortable by link, target, created timestamp, updated timestamp, and clicks.