### PR TITLE
public: Set json responseType for /api XHRs

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -16,6 +16,8 @@
       if (typeof body === 'object') {
         body = JSON.stringify(body)
         r.setRequestHeader('Content-Type', 'application/json')
+      }
+      if (url.match(/^\/api\//)) {
         r.responseType = 'json'
       }
 
@@ -93,13 +95,7 @@
           (err.message || err.statusText))
       })
       .then(function(xhr) {
-        try {
-          return JSON.parse(xhr.response)
-        } catch (err) {
-          console.error('Bad user info response:', xhr.response)
-          throw new Error('Failed to parse user info response: ' +
-            err.message + '<br/>See console messages for details.')
-        }
+        return xhr.response
       })
   }
 

--- a/public/tests/tests.js
+++ b/public/tests/tests.js
@@ -180,7 +180,7 @@ describe('Custom Links', function() {
         ]
 
         xhr.withArgs('GET', '/api/user/' + USER_ID).returns(
-          Promise.resolve({ response: JSON.stringify({ links: usersLinks }) }))
+          Promise.resolve({ response: { links: usersLinks } }))
         return backend.getUserInfo(USER_ID).should.become({ links: usersLinks })
       })
 
@@ -200,17 +200,6 @@ describe('Custom Links', function() {
           Promise.reject({ statusText: 'Forbidden' }))
         return backend.getUserInfo(USER_ID).should.be.rejectedWith(
           'Request for user info failed: Forbidden')
-      })
-
-      it('rejects with a parse error from invalid response text', function() {
-        xhr.withArgs('GET', '/api/user/' + USER_ID).returns(
-          Promise.resolve({ response: 'foobar' }))
-        return backend.getUserInfo(USER_ID)
-          .should.be.rejectedWith('Failed to parse user info response: ')
-          .then(function() {
-            console.error.args[0].should.eql(
-              ['Bad user info response:', 'foobar'])
-          })
       })
     })
 


### PR DESCRIPTION
This eliminates the need for callers to call JSON.parse on API responses.