### PR TITLE
Rename 'count' field to 'clicks'

### DIFF
--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -32,8 +32,8 @@ RedisClient.prototype.getLink = function(link) {
     this.client.hgetall(link, (err, linkData) => {
       if (err) {
         return reject(err)
-      } else if (linkData && linkData.count) {
-        linkData.count = parseInt(linkData.count)
+      } else if (linkData && linkData.clicks) {
+        linkData.clicks = parseInt(linkData.clicks)
       }
       resolve(linkData)
     })
@@ -42,7 +42,7 @@ RedisClient.prototype.getLink = function(link) {
 
 RedisClient.prototype.recordAccess = function(link) {
   return new Promise((resolve, reject) => {
-    this.client.hincrby(link, 'count', 1, err => err ? reject(err) : resolve())
+    this.client.hincrby(link, 'clicks', 1, err => err ? reject(err) : resolve())
   })
 }
 
@@ -72,11 +72,11 @@ RedisClient.prototype.createLink = function(link, target, owner) {
         'target', target,
         'created', createdStamp,
         'updated', createdStamp,
-        'count', 0,
+        'clicks', 0,
         err => {
           if (err) {
             return reject(new Error(link + ' created, ' +
-              'but failed to set target, count, and timestamps: ' + err))
+              'but failed to set target, clicks, and timestamps: ' + err))
           }
           resolve(true)
         })

--- a/public/app.js
+++ b/public/app.js
@@ -279,7 +279,7 @@
       cells[1].appendChild(cl.createAnchor(link.target))
       cells[2].textContent = cl.dateStamp(link.created)
       cells[3].textContent = cl.dateStamp(link.updated)
-      cells[4].textContent = link.count
+      cells[4].textContent = link.clicks
       actions[1].onclick = function() {
         cl.confirmDelete(link.link, current, linksView).open()
       }

--- a/public/tests/tests.js
+++ b/public/tests/tests.js
@@ -174,9 +174,9 @@ describe('Custom Links', function() {
 
       it('returns user info from a successful response', function() {
         var usersLinks = [
-            { link: '/foo', target: 'https://foo.com/', count: 1 },
-            { link: '/bar', target: 'https://bar.com/', count: 2 },
-            { link: '/baz', target: 'https://baz.com/', count: 3 }
+            { link: '/foo', target: 'https://foo.com/', clicks: 1 },
+            { link: '/bar', target: 'https://bar.com/', clicks: 2 },
+            { link: '/baz', target: 'https://baz.com/', clicks: 3 }
         ]
 
         xhr.withArgs('GET', '/api/user/' + USER_ID).returns(
@@ -785,7 +785,7 @@ describe('Custom Links', function() {
             target: 'https://foo.com/',
             created: '0987654321',
             updated: '1234567890',
-            count: 3
+            clicks: 3
           }],
           table = cl.createLinksTable(links, linksView),
           linkRow = table.children[1],
@@ -821,7 +821,7 @@ describe('Custom Links', function() {
     })
 
     it('launches a dialog box to confirm deletion', function() {
-      var links = [{ link: '/foo', target: 'https://foo.com/', count: 3 }],
+      var links = [{ link: '/foo', target: 'https://foo.com/', clicks: 3 }],
           table = cl.createLinksTable(links, linksView),
           row = table.getElementsByClassName('link')[0],
           deleteButton = row.getElementsByTagName('button')[1],
@@ -839,9 +839,9 @@ describe('Custom Links', function() {
 
     it('returns a table of multiple elements sorted by link', function() {
       var links =[
-            { link: '/foo', target: 'https://foo.com/', count: 1 },
-            { link: '/bar', target: 'https://bar.com/', count: 2 },
-            { link: '/baz', target: 'https://baz.com/', count: 3 }
+            { link: '/foo', target: 'https://foo.com/', clicks: 1 },
+            { link: '/bar', target: 'https://bar.com/', clicks: 2 },
+            { link: '/baz', target: 'https://baz.com/', clicks: 3 }
           ],
           table = cl.createLinksTable(links, linksView),
           rows = table.getElementsByClassName('link')
@@ -854,11 +854,11 @@ describe('Custom Links', function() {
 
     it('returns a table of multiple elements sorted by clicks', function() {
       var links = [
-              { link: '/foo', target: 'https://foo.com/', count: 1 },
-              { link: '/bar', target: 'https://bar.com/', count: 2 },
-              { link: '/baz', target: 'https://baz.com/', count: 3 }
+              { link: '/foo', target: 'https://foo.com/', clicks: 1 },
+              { link: '/bar', target: 'https://bar.com/', clicks: 2 },
+              { link: '/baz', target: 'https://baz.com/', clicks: 3 }
           ],
-          tableOptions = { sortKey: 'count', order: 'descending' },
+          tableOptions = { sortKey: 'clicks', order: 'descending' },
           table = cl.createLinksTable(links, linksView, tableOptions),
           rows = table.getElementsByClassName('link')
 
@@ -908,7 +908,7 @@ describe('Custom Links', function() {
 
     it('shows a single link', function() {
       setApiResponseLinks([
-        { link: '/foo', target: 'https://foo.com/', count: 1 }
+        { link: '/foo', target: 'https://foo.com/', clicks: 1 }
       ])
       return cl.linksView().then(function(view) {
         var linksTable = view.element.getElementsByClassName('links')[0],
@@ -929,9 +929,9 @@ describe('Custom Links', function() {
 
     it('shows multiple links', function() {
       setApiResponseLinks([
-        { link: '/foo', target: 'https://foo.com/', count: 1 },
-        { link: '/bar', target: 'https://bar.com/', count: 2 },
-        { link: '/baz', target: 'https://baz.com/', count: 3 }
+        { link: '/foo', target: 'https://foo.com/', clicks: 1 },
+        { link: '/bar', target: 'https://bar.com/', clicks: 2 },
+        { link: '/baz', target: 'https://baz.com/', clicks: 3 }
       ])
       return cl.linksView().then(function(view) {
         var linksTable = view.element.getElementsByClassName('links')[0],

--- a/tests/server/app-test.js
+++ b/tests/server/app-test.js
@@ -152,7 +152,7 @@ describe('assembleApp', function() {
     it('redirects to the target URL returned by the LinkDb', function() {
       getLink.withArgs('/foo', { recordAccess: true })
         .returns(Promise.resolve(
-          { target: LINK_TARGET, owner: 'mbland@acm.org', count: 27 }))
+          { target: LINK_TARGET, owner: 'mbland@acm.org', clicks: 27 }))
 
       return request(app)
         .get('/foo')
@@ -216,7 +216,7 @@ describe('assembleApp', function() {
           owner: 'mbland@acm.org',
           created: '1234567890',
           updated: '1234567890',
-          count: 27
+          clicks: 27
         }
         getLink.withArgs('/foo').returns(Promise.resolve(linkData))
 
@@ -331,9 +331,9 @@ describe('assembleApp', function() {
       it('returns the list of redirect info owned by the user', function() {
         // Not including the owner, though it would be normally.
         var links = [
-          { link: '/foo', target: LINK_TARGET, count: 27 },
-          { link: '/bar', target: LINK_TARGET, count: 28 },
-          { link: '/baz', target: LINK_TARGET, count: 29 }
+          { link: '/foo', target: LINK_TARGET, clicks: 27 },
+          { link: '/bar', target: LINK_TARGET, clicks: 28 },
+          { link: '/baz', target: LINK_TARGET, clicks: 29 }
         ]
 
         getOwnedLinks.withArgs('mbland@acm.org')

--- a/tests/server/link-db-test.js
+++ b/tests/server/link-db-test.js
@@ -85,7 +85,7 @@ describe('LinkDb', function() {
     })
 
     it('returns the data for a known link', function() {
-      var linkData = { target: LINK_TARGET, owner: 'mbland', count: 27 }
+      var linkData = { target: LINK_TARGET, owner: 'mbland', clicks: 27 }
 
       stubClientMethod('getLink').withArgs('/foo')
         .returns(Promise.resolve(linkData))
@@ -98,7 +98,7 @@ describe('LinkDb', function() {
     })
 
     it('records access of a known link', function() {
-      var linkData = { target: LINK_TARGET, owner: 'mbland', count: 27 }
+      var linkData = { target: LINK_TARGET, owner: 'mbland', clicks: 27 }
 
       stubClientMethod('getLink').withArgs('/foo')
         .returns(Promise.resolve(linkData))
@@ -112,7 +112,7 @@ describe('LinkDb', function() {
     })
 
     it('logs an error if the link is known but recordAccess fails', function() {
-      var linkData = { target: LINK_TARGET, owner: 'mbland', count: 27 },
+      var linkData = { target: LINK_TARGET, owner: 'mbland', clicks: 27 },
           errorSpy = sinon.spy(logger, 'error')
 
       stubClientMethod('getLink').withArgs('/foo')
@@ -230,14 +230,14 @@ describe('LinkDb', function() {
         .returns(Promise.resolve(['/baz', '/bar', '/foo']))
       stubClientMethod('getLink').callsFake(function(link) {
         return Promise.resolve({
-          link: link, target: LINK_TARGET, owner: 'mbland', count: 0 })
+          link: link, target: LINK_TARGET, owner: 'mbland', clicks: 0 })
       })
 
       return linkDb.getOwnedLinks('mbland')
         .should.become([
-          { link: '/baz', target: LINK_TARGET, owner: 'mbland', count: 0 },
-          { link: '/bar', target: LINK_TARGET, owner: 'mbland', count: 0 },
-          { link: '/foo', target: LINK_TARGET, owner: 'mbland', count: 0 }
+          { link: '/baz', target: LINK_TARGET, owner: 'mbland', clicks: 0 },
+          { link: '/bar', target: LINK_TARGET, owner: 'mbland', clicks: 0 },
+          { link: '/foo', target: LINK_TARGET, owner: 'mbland', clicks: 0 }
         ])
     })
 
@@ -269,7 +269,7 @@ describe('LinkDb', function() {
           return Promise.reject(new Error('forced failure for ' + link))
         }
         return Promise.resolve({
-          link: link, target: LINK_TARGET, owner: 'mbland', count: 0 })
+          link: link, target: LINK_TARGET, owner: 'mbland', clicks: 0 })
       })
       return linkDb.getOwnedLinks('mbland')
         .should.be.rejectedWith(Error, 'forced failure for /bar')

--- a/tests/server/redis-client-test.js
+++ b/tests/server/redis-client-test.js
@@ -49,12 +49,12 @@ describe('RedisClient', function() {
     return helpers.killServer(redisServer)
   })
 
-  setData = function(link, target, owner, count) {
+  setData = function(link, target, owner, clicks) {
     return new Promise(function(resolve, reject) {
       clientImpl.hmset('/foo',
         'target', target,
         'owner', owner,
-        'count', count,
+        'clicks', clicks,
         function(err) {
           err ? reject(err) : resolve()
         })
@@ -141,11 +141,11 @@ describe('RedisClient', function() {
       return redisClient.getLink('/foo').should.become(null)
     })
 
-    it('returns data if link exists, converts count to int', function() {
+    it('returns data if link exists, converts clicks to int', function() {
       return setData('/foo', LINK_TARGET, 'mbland', 0).should.be.fulfilled
         .then(function() {
           return redisClient.getLink('/foo').should.become({
-            target: LINK_TARGET, owner: 'mbland', count: 0
+            target: LINK_TARGET, owner: 'mbland', clicks: 0
           })
         })
     })
@@ -160,14 +160,14 @@ describe('RedisClient', function() {
   })
 
   describe('recordAccess', function() {
-    it('increments the count for a link', function() {
+    it('increments the clicks for a link', function() {
       return setData('/foo', LINK_TARGET, 'mbland', 0).should.be.fulfilled
         .then(function() {
           return redisClient.recordAccess('/foo').should.be.fulfilled
         })
         .then(function() {
           return redisClient.getLink('/foo').should.become({
-            target: LINK_TARGET, owner: 'mbland', count: 1
+            target: LINK_TARGET, owner: 'mbland', clicks: 1
           })
         })
     })
@@ -177,7 +177,7 @@ describe('RedisClient', function() {
         cb(new Error('forced error for ' + [link, field, val].join(' ')))
       })
       return redisClient.recordAccess('/foo')
-        .should.be.rejectedWith(Error, 'forced error for /foo count 1')
+        .should.be.rejectedWith(Error, 'forced error for /foo clicks 1')
     })
   })
 
@@ -260,7 +260,7 @@ describe('RedisClient', function() {
           owner: 'mbland',
           created: fakeTimestamp,
           updated: fakeTimestamp,
-          count: 0
+          clicks: 0
         })
     })
 
@@ -291,10 +291,10 @@ describe('RedisClient', function() {
         })
       return redisClient.createLink('/foo', LINK_TARGET, 'mbland')
         .should.be.rejectedWith(Error,
-          'failed to set target, count, and timestamps: ' +
+          'failed to set target, clicks, and timestamps: ' +
           'Error: forced error for /foo target ' + LINK_TARGET +
           ' created ' + fakeTimestamp + ' updated ' + fakeTimestamp +
-          ' count 0')
+          ' clicks 0')
         .then(function() {
           return redisClient.getLink('/foo')
             .should.become({ owner: 'mbland' })
@@ -350,7 +350,7 @@ describe('RedisClient', function() {
           target: LINK_TARGET,
           created: fakeTimestamp,
           updated: updateTimestamp,
-          count: 0
+          clicks: 0
         })
     })
 


### PR DESCRIPTION
This makes it consistent with the use of the term 'clicks' in the user interface, which is a bit more clear than 'count' when describing the number of times a link has been used.