### PR TITLE
public: Add inactive link editing view

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,9 @@ body{margin-top:30px;}
 .clicks-action button{width:100%;}
 .dialog-overlay{position:fixed;top:0;right:0;bottom:0;left:0;background:rgba(0,0,0,0.3);z-index:2;}
 .dialog {width:375px;position:relative;background:whitesmoke;border-radius:5px;margin:20% auto;padding:10px 0;text-align:center;font-weight:bold;border:medium solid black;z-index:3;}
+.edit-view .info{margin-bottom:1em;}
+.edit-view .info .row{display:flex;justify-content:flex-start;}
+.edit-view .label{font-weight:bold;width:110px;}
 @media (max-width:849px){
 .clicks-action{flex:0 0;}
 }
@@ -61,6 +64,38 @@ body{margin-top:30px;}
         <button class='button-primary' type='submit'>Create link</button>
         <div class='result'></div>
       </form>
+      <div class='edit-view'>
+        <div class='info'>
+          <div class='row'>
+            <div class='label cell'>Editing link:</div>
+            <div class='cell' data-name='link'>[link]</div>
+          </div>
+          <div class='row'>
+            <div class='label cell'>Clicks:</div>
+            <div class='cell' data-name='clicks'>[clicks]</div>
+          </div>
+          <div class='row'>
+            <div class='label cell'>Created:</div>
+            <div class='cell' data-name='created'>[stamp]</div>
+          </div>
+          <div class='row'>
+            <div class='label cell'>Last updated:</div>
+            <div class='cell' data-name='updated'>[stamp]</div>
+          </div>
+        </div>
+        <form action='/api/target'>
+          <label>Target URL:</label>
+          <input class='u-full-width' data-name='target'/>
+          <button class='button-primary' type='submit'>Update target</button>
+          <div class='result'></div>
+        </form>
+        <form action='/api/owner'>
+          <label>Owner:</label>
+          <input class='u-full-width' data-name='owner'/>
+          <button class='button-primary' type='submit'>Change owner</button>
+          <div class='result'></div>
+        </form>
+      </div>
       <div class='result success'>
       </div>
       <div class='result failure'>

--- a/public/tests/lib.js
+++ b/public/tests/lib.js
@@ -45,6 +45,20 @@
       console.log('failed to ' + description + ': ' + (err.message || err))
     }
   }
+
+  // For some reason, Firefox's window.getSelection() returns the empty string,
+  // hence we can't just do:
+  //
+  //   document.getSelection().toString().should.equal(data.target)
+  //
+  // See:
+  // - https://stackoverflow.com/a/20427804
+  // - https://stackoverflow.com/a/10596963
+  // - https://bugzilla.mozilla.org/show_bug.cgi?id=85686
+  clTest.getSelection = function() {
+    var element = document.activeElement
+    return element.value.substring(element.selectionStart, element.selectionEnd)
+  }
 })
 
 before(function() {


### PR DESCRIPTION
This view will eventually enable the user to update the target URL of an existing link, or to assign the link to a new owner. This change contains the main view elements, but the button click handlers that will provide the actual behavior will be implemented in a future commit.