### PR TITLE
Add Backend.makeApiCall

### DIFF
--- a/public/tests/tests.js
+++ b/public/tests/tests.js
@@ -12,7 +12,6 @@ describe('Custom Links', function() {
       prepareFlashingElement,
       useFakeFade,
       USER_ID = 'mbland@acm.org',
-      HOST_PREFIX = window.location.protocol + '//' + window.location.host,
       LINK_TARGET = 'https://mike-bland.com/'
 
   beforeEach(function() {
@@ -213,8 +212,7 @@ describe('Custom Links', function() {
           .withArgs('POST', '/api/create/foo', { target: 'https://foo.com/' })
           .returns(Promise.resolve())
         return backend.createLink('foo', 'https://foo.com/')
-          .should.become('<a href=\'/foo\'>' +
-            window.location.protocol + '//' + window.location.host +
+          .should.become('<a href=\'/foo\'>' +  window.location.origin +
             '/foo</a> now redirects to https://foo.com/')
       })
 
@@ -306,9 +304,9 @@ describe('Custom Links', function() {
 
         navLinks = navBar.getElementsByTagName('A')
         navLinks.length.should.equal(3)
-        navLinks[0].href.should.equal(HOST_PREFIX + '/#')
-        navLinks[1].href.should.equal(HOST_PREFIX + '/#create')
-        navLinks[2].href.should.equal(HOST_PREFIX + '/logout')
+        navLinks[0].href.should.equal(window.location.origin + '/#')
+        navLinks[1].href.should.equal(window.location.origin + '/#create')
+        navLinks[2].href.should.equal(window.location.origin + '/logout')
       })
     })
   })
@@ -834,7 +832,7 @@ describe('Custom Links', function() {
       anchors = linkTarget.getElementsByTagName('a')
       anchors.length.should.equal(2)
       anchors[0].textContent.should.equal('/foo')
-      anchors[0].href.should.equal(HOST_PREFIX + '/foo')
+      anchors[0].href.should.equal(window.location.origin + '/foo')
       anchors[1].textContent.should.equal('https://foo.com/')
       anchors[1].href.should.equal('https://foo.com/')
 
@@ -1358,7 +1356,8 @@ describe('Custom Links', function() {
           return view.done()
         })
         .then(function() {
-          element.textContent.should.equal(HOST_PREFIX + '/foo is owned by msb')
+          element.textContent.should.equal(window.location.origin +
+            '/foo is owned by msb')
         })
     })
 


### PR DESCRIPTION
This new function eliminates some common boilerplate across backend calls and simplifies testing, i.e. we only have to check the args that each Backend function passes to Backend.makeApiCall, not the success and failure response for each function.

A future commit will change the remaining Backend member functions to use Backend.makeApiCall, since they currently behave slightly differently.

Also contains a commit to replace `HOST_PREFIX` in `public/tests/tests.js` with `window.location.origin`. Considering that I'd used `window.location.origin` in other test cases, I don't know why I created `HOST_PREFIX` to begin with.