### PR TITLE
Launch redis-server by default from `./go serve`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage/
 dump.rdb
 node_modules/
 npm.log
+redis.log
 public/tests/generated/
 screenshot*.png
 scripts/go-script-bash/

--- a/go
+++ b/go
@@ -1,9 +1,12 @@
 #! /usr/bin/env bash
 #
-# Serverless system for creating custom URLs
+# System for creating custom URLs
 #
-# Allows authenticated users to create and access custom URLs that redirect to
-# arbitrary targets.
+# Allows authenticated users to create and access custom links that redirect to
+# arbitrary target URLs.
+#
+# See .config/env.template for instructions on setting environment variables to
+# configure your local development environment.
 
 # The path where your command scripts reside
 declare GO_SCRIPTS_DIR="${GO_SCRIPTS_DIR:-scripts}"

--- a/scripts/serve
+++ b/scripts/serve
@@ -1,14 +1,30 @@
 #! /usr/local/env bash
 #
-# Runs a local url-pointers server
+# Runs a local Custom Links server
 #
 # Usage:
 #   {{go}} {{cmd}} [<config-file>]
 #
 # Where:
-#   <config-file>  url-pointers configuration file
+#   <config-file>  configuration file; {{root}}/test-config.json by default
 #
-# There must be a redis-server already running.
+# Environment variables:
+#   CUSTOM_LINKS_REDIS_PORT      Port on which redis-server will run/is running
+#   CUSTOM_LINKS_REDIS_LOG_FILE  Log file for automatically-started redis-server
+#
+# If redis-server is already running, it must be running on either the default
+# port or on the port specified by CUSTOM_LINKS_REDIS_PORT (or by REDIS_PORT in
+# the <config-file>; jq must be installed to read it from the <config-file>.)
+#
+# If redis-server isn't already running, it will be started automatically,
+# either on the default port or CUSTOM_LINKS_REDIS_PORT. redis-server log output
+# will then stream to either CUSTOM_LINKS_REDIS_LOG_PATH or {{root}}/redis.log
+# by default. (This variable cannot be defined in the <config-file>.)
+
+export CUSTOM_LINKS_REDIS_LOG_PATH="${CUSTOM_LINKS_REDIS_LOG_PATH:-redis.log}"
+export CUSTOM_LINKS_REDIS_PID=''
+
+. "$_GO_USE_MODULES" 'log'
 
 cl.serve_tab_completion() {
   local word_index="$1"
@@ -18,6 +34,33 @@ cl.serve_tab_completion() {
 
   if [[ "$word_index" -eq '0' ]]; then
     @go.compgen -f -- "$word"
+  fi
+}
+
+cl.serve_launch_redis() {
+  local server_config="$1"
+  local args=('redis-server')
+  local redis_port="${CUSTOM_LINKS_REDIS_PORT:-null}"
+  local redis_regex='[r]edis-server .*:'
+
+  if [[ "$redis_port" == 'null' ]] && command -v jq >/dev/null; then
+    redis_port="$(jq '.REDIS_PORT' "$server_config")"
+  fi
+  if [[ "$redis_port" == 'null' ]]; then
+    redis_port='6379'
+  fi
+  args+=('--port' "$redis_port")
+  redis_regex+="$redis_port"
+
+  if ! grep -q -- "$redis_regex" <(ps aux); then
+    @go.log RUN Launching redis-server on port "$redis_port"
+    "${args[@]}" >> "$CUSTOM_LINKS_REDIS_LOG_PATH" 2>&1 &
+    CUSTOM_LINKS_REDIS_PID="$!"
+
+    if ! grep -q -- "$redis_regex" <(ps aux); then
+      @go.log FATAL Failed to launch redis-server
+    fi
+    @go.log INFO redis-server running as PID "$CUSTOM_LINKS_REDIS_PID"
   fi
 }
 
@@ -33,6 +76,7 @@ cl.serve() {
     ;;
   esac
 
+  cl.serve_launch_redis "$server_config"
   node "$_GO_ROOTDIR/index.js" "$server_config"
 }
 


### PR DESCRIPTION
Rather than require that the user always start redis-server separately, the `./go serve` command will attempt to launch it automatically if it isn't already running. Stoping the `./go serve` script with CTRL-C will also automatically stop the redis-server.

Also contains tweaks to the header comment for the ./go script itself.