### PR TITLE
Build err message before throwing Error from Config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -107,6 +107,7 @@ function allAuthProviderFields() {
 
 function validateConfig(config) {
   var errors = [],
+      errMsg,
       requiredFields,
       optionalFields,
       authProviders = config.AUTH_PROVIDERS || [],
@@ -132,7 +133,8 @@ function validateConfig(config) {
   }
 
   if (errors.length !== 0) {
-    throw new Error('Invalid configuration:\n  ' + errors.join('\n  '))
+    errMsg = 'Invalid configuration:\n  ' + errors.join('\n  ')
+    throw new Error(errMsg)
   }
 }
 


### PR DESCRIPTION
On Alpine Linux, the 'fails to launch due to missing variables' test case from `tests/server/smoke-test.js` would intermittently fail due to the error message not containing the result of the `errors.join` expression. It would seem that the runtime failed to evaluate the temporary expression to build the error message string before passing it to the Error constructor.

While this seems like a platform bug with Node.js on Alpine/musl libc, the workaround is trivial.