### PR TITLE
Allow env vars to override config file

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -87,7 +87,7 @@ function applyEnvUpdates(configData) {
 function assignEnvVarToConfigProperty(configData) {
   return property => {
     var envVar = process.env['CUSTOM_LINKS_' + property]
-    if (!configData[property] && envVar !== undefined) {
+    if (envVar !== undefined) {
       configData[property] = envVar
     }
   }

--- a/tests/helpers/env-vars.js
+++ b/tests/helpers/env-vars.js
@@ -1,0 +1,33 @@
+'use strict'
+
+module.exports = EnvVars
+
+function EnvVars(prefix) {
+  this.prefix = prefix
+  this.varsToDelete = []
+  this.varsToRestore = []
+}
+
+EnvVars.prototype.setEnvVar = function(name, value) {
+  name = this.prefix + name
+  process.env[name] = value
+  this.varsToDelete.push(name)
+}
+
+EnvVars.prototype.saveEnvVars = function() {
+  Object.keys(process.env).forEach(name => {
+    if (name.startsWith(this.prefix)) {
+      this.varsToRestore[name] = process.env[name]
+      delete process.env[name]
+    }
+  })
+}
+
+EnvVars.prototype.restoreEnvVars = function() {
+  this.varsToDelete.forEach(function(name) {
+    delete process.env[name]
+  })
+  Object.keys(this.varsToRestore).forEach(name => {
+    process.env[name] = this.varsToRestore[name]
+  })
+}

--- a/tests/helpers/index.js
+++ b/tests/helpers/index.js
@@ -20,6 +20,30 @@ module.exports = exports = {
     return JSON.parse(JSON.stringify(testConfig))
   },
 
+  setEnvVar(name, value, varsToDelete) {
+    name = 'CUSTOM_LINKS_' + name
+    process.env[name] = value
+    varsToDelete.push(name)
+  },
+
+  saveEnvVars(varsToRestore) {
+    Object.keys(process.env).forEach(function(name) {
+      if (name.startsWith('CUSTOM_LINKS_')) {
+        varsToRestore[name] = process.env[name]
+        delete process.env[name]
+      }
+    })
+  },
+
+  restoreEnvVars(varsToDelete, varsToRestore) {
+    varsToDelete.forEach(function(name) {
+      delete process.env[name]
+    })
+    Object.keys(varsToRestore).forEach(function(name) {
+      process.env[name] = varsToRestore[name]
+    })
+  },
+
   pickUnusedPort() {
     return new Promise(resolve => {
       var server = net.createServer()

--- a/tests/server/smoke-test.js
+++ b/tests/server/smoke-test.js
@@ -2,6 +2,7 @@
 
 var path = require('path')
 var helpers = require('../helpers')
+var EnvVars = require('../helpers/env-vars')
 var chai = require('chai')
 var chaiAsPromised = require('chai-as-promised')
 
@@ -12,17 +13,19 @@ describe('Smoke test', function() {
   var testConfig = path.join(
         path.dirname(__dirname), 'helpers', 'system-test-config.json'),
       doLaunch,
-      serverInfo
+      serverInfo,
+      envVars
 
   this.timeout(5000)
 
   beforeEach(function() {
     serverInfo = null
-    delete process.env.CUSTOM_LINKS_CONFIG_PATH
+    envVars = new EnvVars('CUSTOM_LINKS_')
+    envVars.saveEnvVars()
   })
 
   afterEach(function() {
-    delete process.env.CUSTOM_LINKS_CONFIG_PATH
+    envVars.restoreEnvVars()
     if (serverInfo === null) {
       return
     }
@@ -50,7 +53,7 @@ describe('Smoke test', function() {
   })
 
   it('launches using CUSTOM_LINKS_CONFIG_PATH', function() {
-    process.env.CUSTOM_LINKS_CONFIG_PATH = testConfig
+    envVars.setEnvVar('CUSTOM_LINKS_CONFIG_PATH', testConfig)
     return doLaunch()
   })
 


### PR DESCRIPTION
This seems a bit more in line with the principle of least surprise. Also extracts the `EnvVar` helper class from the `Config` test for reuse in the smoke test.