### PR TITLE
config: Add REDIS_HOST configuration variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,10 +18,8 @@ var customLinks = require('./lib')
 var morgan = require('morgan')
 var logger = console
 
-if (config.REDIS_PORT !== undefined) {
-  redisClientOptions.port = config.REDIS_PORT
-  redisStoreOptions.port = config.REDIS_PORT
-}
+redisClientOptions.host = redisStoreOptions.host = config.REDIS_HOST
+redisClientOptions.port = redisStoreOptions.port = config.REDIS_PORT
 
 var redisClient = redis.createClient(redisClientOptions)
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -46,6 +46,7 @@ var schema = {
   },
   optionalTopLevelFields: {
     SESSION_MAX_AGE: 'maximum age of a session, in seconds',
+    REDIS_HOST: 'redis-server host',
     REDIS_PORT: 'redis-server port',
     users: 'list of authorized usernames (email addresses)',
     domains: 'list of authorized domains'
@@ -70,6 +71,7 @@ function applyEnvUpdates(configData) {
     'AUTH_PROVIDERS',
     'SESSION_SECRET',
     'SESSION_MAX_AGE',
+    'REDIS_HOST',
     'REDIS_PORT'
   ]
 

--- a/tests/server/config-test.js
+++ b/tests/server/config-test.js
@@ -89,6 +89,7 @@ describe('config', function() {
           'AUTH_PROVIDERS',
           'SESSION_SECRET',
           'SESSION_MAX_AGE',
+          'REDIS_HOST',
           'REDIS_PORT',
           'GOOGLE_CLIENT_ID',
           'GOOGLE_CLIENT_SECRET',
@@ -96,8 +97,8 @@ describe('config', function() {
         ],
         config
 
-    inputConfig.REDIS_PORT = 666
-    compareConfig.REDIS_PORT = 666
+    inputConfig.REDIS_HOST = compareConfig.REDIS_HOST = 'redis'
+    inputConfig.REDIS_PORT = compareConfig.REDIS_PORT = 666
 
     properties.forEach(function(name) {
       var value = inputConfig[name]
@@ -112,6 +113,8 @@ describe('config', function() {
       .to.equal(compareConfig.SESSION_SECRET)
     expect(config.SESSION_MAX_AGE)
       .to.equal(compareConfig.SESSION_MAX_AGE)
+    expect(config.REDIS_HOST)
+      .to.equal(compareConfig.REDIS_HOST)
     expect(config.REDIS_PORT)
       .to.equal(compareConfig.REDIS_PORT)
     expect(config.GOOGLE_CLIENT_ID)


### PR DESCRIPTION
This is in anticipation of running the server in a container or any other environment in which redis is running on another host.