### PR TITLE
main: Wait for Redis to be ready before listening

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,10 +31,14 @@ customLinks.assembleApp(
   new RedisStore(redisStoreOptions),
   config)
 
-var server = app.listen(config.PORT)
+var server = { close() { } }
+
+redisClient.on('ready', () => {
+  server = app.listen(config.PORT)
+  logger.log(packageInfo.name + ' listening on port ' + config.PORT)
+})
 
 process.on('exit', () => {
   server.close()
   redisClient.quit()
 })
-logger.log(packageInfo.name + ' listening on port ' + config.PORT)

--- a/tests/server/smoke-test.js
+++ b/tests/server/smoke-test.js
@@ -61,4 +61,10 @@ describe('Smoke test', function() {
     return doLaunch(null).should.be.rejectedWith(Error,
       'missing AUTH_PROVIDERS')
   })
+
+  it('fails due to a bad redis host', function() {
+    process.env.CUSTOM_LINKS_REDIS_HOST = 'nonexistent-redis-host'
+    return doLaunch().should.be.rejectedWith(Error,
+      /Redis connection to nonexistent-redis-host:[0-9]+ failed/)
+  })
 })


### PR DESCRIPTION
Updates the main program in `index.js` to begin listening for requests only after the `RedisClient` emits a `ready` event. Without this change, the new test case would fail, as the `custom-links listening on port ...` message would get emitted before any error message due to a failure to connect to Redis.