### PR TITLE
Use headless Chrome on CI/Travis

### DIFF
--- a/.config/karma.conf.js
+++ b/.config/karma.conf.js
@@ -42,8 +42,9 @@ module.exports = function(config) {
     detectBrowsers: {
       // Work around karma-detect-browsers adding multiple Firefox builds, and
       // force Chrome to run in headless mode by default on integration systems:
-      // https://developers.google.com/web/updates/2017/04/headless-chrome
-      // https://developers.google.com/web/updates/2017/06/headless-karma-mocha-chai
+      // - https://developers.google.com/web/updates/2017/04/headless-chrome
+      // eslint-disable-next-line max-len
+      // - https://developers.google.com/web/updates/2017/06/headless-karma-mocha-chai
       postDetection(browsers) {
         return browsers
           .filter(b => !b.startsWith('Firefox') || b === 'Firefox')

--- a/.config/karma.conf.js
+++ b/.config/karma.conf.js
@@ -40,12 +40,14 @@ module.exports = function(config) {
     // karma-detect-browsers.
     browsers: [],
     detectBrowsers: {
-      // Work around karma-detect-browsers adding multiple Firefox builds.
+      // Work around karma-detect-browsers adding multiple Firefox builds, and
+      // force Chrome to run in headless mode by default on integration systems:
+      // https://developers.google.com/web/updates/2017/04/headless-chrome
+      // https://developers.google.com/web/updates/2017/06/headless-karma-mocha-chai
       postDetection(browsers) {
-        if (process.platform !== 'linux') {
-          return browsers
-        }
-        return browsers.filter(b => !b.startsWith('Firefox') || b === 'Firefox')
+        return browsers
+          .filter(b => !b.startsWith('Firefox') || b === 'Firefox')
+          .map(b => (b === 'Chrome' && process.env.CI) ? 'ChromeHeadless' : b)
       }
     },
 

--- a/.config/karma.conf.js
+++ b/.config/karma.conf.js
@@ -59,8 +59,6 @@ module.exports = function(config) {
   if (process.env.CI === 'true') {
     options.autoWatch = false
     options.singleRun = true
-    options.browsers = [ 'Chrome', 'Firefox' ]
-    options.detectBrowsers.enabled = false
   }
 
   if (process.env.KARMA_BROWSERS !== undefined) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -658,7 +658,7 @@
         "buffer-xor": "1.0.3",
         "cipher-base": "1.0.4",
         "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.0",
+        "evp_bytestokey": "1.0.2",
         "inherits": "2.0.3"
       }
     },
@@ -670,7 +670,7 @@
       "requires": {
         "browserify-aes": "1.0.6",
         "browserify-des": "1.0.0",
-        "evp_bytestokey": "1.0.0"
+        "evp_bytestokey": "1.0.2"
       }
     },
     "browserify-des": {
@@ -907,9 +907,9 @@
       }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "cliui": {
@@ -1070,7 +1070,7 @@
         "convert-source-map": "1.1.3",
         "inline-source-map": "0.6.2",
         "lodash.memoize": "3.0.4",
-        "source-map": "0.5.6"
+        "source-map": "0.5.7"
       }
     },
     "combined-stream": {
@@ -1481,7 +1481,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.27"
+        "es5-ext": "0.10.29"
       }
     },
     "dashdash": {
@@ -1830,9 +1830,9 @@
       "dev": true
     },
     "es5-ext": {
-      "version": "0.10.27",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.27.tgz",
-      "integrity": "sha512-3KXJRYzKXTd7xfFy5uZsJCXue55fAYQ035PRjyYk2PicllxIwcW9l3AbM/eGaw3vgVAUW4tl4xg9AXDEI6yw0w==",
+      "version": "0.10.29",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.29.tgz",
+      "integrity": "sha512-KXla9NXo5sdaEkGSmbFPYgjH6m75kxsthL6GDRSug/Y2OiMoYm0I9giL39j4cgmaFmAbkIFJ6gG+SGKnLSmOvA==",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.1",
@@ -1846,7 +1846,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.27",
+        "es5-ext": "0.10.29",
         "es6-symbol": "3.1.1"
       }
     },
@@ -1857,7 +1857,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.27",
+        "es5-ext": "0.10.29",
         "es6-iterator": "2.0.1",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -1876,7 +1876,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.27",
+        "es5-ext": "0.10.29",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -1889,7 +1889,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.27"
+        "es5-ext": "0.10.29"
       }
     },
     "es6-weak-map": {
@@ -1899,7 +1899,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.27",
+        "es5-ext": "0.10.29",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1"
       }
@@ -2079,7 +2079,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.27"
+        "es5-ext": "0.10.29"
       }
     },
     "event-stream": {
@@ -2110,12 +2110,13 @@
       "dev": true
     },
     "evp_bytestokey": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
-      "integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.2.tgz",
+      "integrity": "sha512-ni0r0lrm7AOzsh2qC5mi9sj8S0gmj5fLNjfFpxN05FB4tAVZEKotbkjOtLPqTCX/CXT7NsUr6juZb4IFJeNNdA==",
       "dev": true,
       "requires": {
-        "create-hash": "1.1.3"
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.1"
       }
     },
     "exit-hook": {
@@ -3796,7 +3797,7 @@
       "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.6"
+        "source-map": "0.5.7"
       }
     },
     "inquirer": {
@@ -3809,7 +3810,7 @@
         "ansi-regex": "2.1.1",
         "chalk": "1.1.3",
         "cli-cursor": "1.0.2",
-        "cli-width": "2.1.0",
+        "cli-width": "2.2.0",
         "figures": "1.7.0",
         "lodash": "4.17.4",
         "readline2": "1.0.1",
@@ -4381,7 +4382,7 @@
         "rimraf": "2.6.1",
         "safe-buffer": "5.1.1",
         "socket.io": "1.7.3",
-        "source-map": "0.5.6",
+        "source-map": "0.5.7",
         "tmp": "0.0.31",
         "useragent": "2.2.1"
       },
@@ -4893,6 +4894,28 @@
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
+    },
+    "md5.js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+      "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+      "dev": true,
+      "requires": {
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "hash-base": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+          "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
     },
     "media-typer": {
       "version": "0.3.0",
@@ -6743,7 +6766,7 @@
         "asn1.js": "4.9.1",
         "browserify-aes": "1.0.6",
         "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.0",
+        "evp_bytestokey": "1.0.2",
         "pbkdf2": "3.0.13"
       }
     },
@@ -7371,7 +7394,7 @@
         "jszip": "3.1.3",
         "rimraf": "2.6.1",
         "tmp": "0.0.30",
-        "xml2js": "0.4.18"
+        "xml2js": "0.4.19"
       },
       "dependencies": {
         "tmp": {
@@ -7708,9 +7731,9 @@
       }
     },
     "source-map": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
     "split": {
@@ -7866,9 +7889,9 @@
       }
     },
     "superagent": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.5.2.tgz",
-      "integrity": "sha1-M2GjlxVnUEw1EGOr6q4PqiPb8/g=",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.6.0.tgz",
+      "integrity": "sha512-oWsu4mboo8sVxagp4bNwZIR1rUmypeAJDmNIwT9mF4k06hSu6P92aOjEWLaIj7vsX3fOUp+cRH/04tao+q5Q7A==",
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
@@ -7878,7 +7901,7 @@
         "form-data": "2.1.4",
         "formidable": "1.1.1",
         "methods": "1.1.2",
-        "mime": "1.3.4",
+        "mime": "1.3.6",
         "qs": "6.4.0",
         "readable-stream": "2.3.3"
       },
@@ -7887,6 +7910,12 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "dev": true
+        },
+        "mime": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
+          "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA=",
           "dev": true
         }
       }
@@ -7898,7 +7927,7 @@
       "dev": true,
       "requires": {
         "methods": "1.1.2",
-        "superagent": "3.5.2"
+        "superagent": "3.6.0"
       }
     },
     "supports-color": {
@@ -8148,7 +8177,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.6",
+        "source-map": "0.5.7",
         "uglify-to-browserify": "1.0.2",
         "yargs": "3.10.0"
       }
@@ -8390,9 +8419,9 @@
       "dev": true
     },
     "xml2js": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.18.tgz",
-      "integrity": "sha512-MMUtkwryoXmYoFUBT32tf7vYPHr98h6VtRLVbsjfmS5hqpp/deRMUNLZNQUHEAY4ChwyBEkisDYhH/EP15X6oA==",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "dev": true,
       "requires": {
         "sax": "1.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,21 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/core-js": {
+      "version": "0.9.43",
+      "resolved": "https://registry.npmjs.org/@types/core-js/-/core-js-0.9.43.tgz",
+      "integrity": "sha512-Y11dktBJ5YwKXX8DfHSb9V6shXKSHN5P2URPZLHTRjX3OsO/u8u1kZnSJvsuSH74aTg8f5ZKcpEeCdIJOcBkHg=="
+    },
+    "@types/mkdirp": {
+      "version": "0.3.29",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.3.29.tgz",
+      "integrity": "sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY="
+    },
+    "@types/node": {
+      "version": "6.0.66",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.66.tgz",
+      "integrity": "sha1-VoC3SmE10z1MAER+fD3GkaRgFiU="
+    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -240,6 +255,11 @@
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
       "dev": true
     },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -393,8 +413,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-arraybuffer": {
       "version": "0.1.5",
@@ -535,7 +554,6 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -750,6 +768,11 @@
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+    },
     "builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -794,6 +817,22 @@
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "dev": true,
       "optional": true
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "requires": {
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        }
+      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -867,6 +906,53 @@
         "path-is-absolute": "1.0.1",
         "readdirp": "2.1.0"
       }
+    },
+    "chrome-launcher": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.4.0.tgz",
+      "integrity": "sha512-Uq34nQ2peVRwyjsyoLs01mL9aEQDbc5RCZWNyYjGPt5ZFPL2B4OazSc98hO6HZOvMUILLL4MyAEVMzA5OvwWug==",
+      "requires": {
+        "@types/core-js": "0.9.43",
+        "@types/mkdirp": "0.3.29",
+        "@types/node": "6.0.66",
+        "lighthouse-logger": "1.0.1",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.1"
+      }
+    },
+    "chrome-remote-interface": {
+      "version": "0.24.4",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.24.4.tgz",
+      "integrity": "sha512-vSBy/FI93B6sTfaRaSl4Dmx6mGvSwT1rpZevPFvQmVSiuNpS/9NGE/3NPl3MkVSXM6JDx9yWKZNkOJ9iMd/hBw==",
+      "requires": {
+        "commander": "2.1.0",
+        "ws": "2.0.3"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+          "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E="
+        },
+        "ultron": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
+          "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ="
+        },
+        "ws": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-2.0.3.tgz",
+          "integrity": "sha1-Uy/UmcP319cg5UPx+AcQbPxX2cs=",
+          "requires": {
+            "ultron": "1.1.0"
+          }
+        }
+      }
+    },
+    "chrome-unmirror": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chrome-unmirror/-/chrome-unmirror-0.1.0.tgz",
+      "integrity": "sha1-6a94ukf3/7kAYCk6cgoBzSbVC6s="
     },
     "chromedriver": {
       "version": "2.31.0",
@@ -1046,6 +1132,19 @@
         }
       }
     },
+    "color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
@@ -1150,8 +1249,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.5.2",
@@ -1469,6 +1567,14 @@
         "randombytes": "2.0.5"
       }
     },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "requires": {
+        "array-find-index": "1.0.2"
+      }
+    },
     "custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
@@ -1518,9 +1624,15 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true,
-      "optional": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "deep-assign": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-2.0.0.tgz",
+      "integrity": "sha1-6+BrHwfwja5ZdiDj3RYi83GhxXI=",
+      "requires": {
+        "is-obj": "1.0.1"
+      }
     },
     "deep-eql": {
       "version": "0.1.3",
@@ -1829,6 +1941,14 @@
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
       "dev": true
     },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
     "es5-ext": {
       "version": "0.10.29",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.29.tgz",
@@ -1912,8 +2032,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.8.1",
@@ -2426,6 +2545,15 @@
         }
       }
     },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
     "flat-cache": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
@@ -2524,8 +2652,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.1.2",
@@ -3447,6 +3574,11 @@
         "is-property": "1.0.2"
       }
     },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -3468,7 +3600,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -3520,8 +3651,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -3685,6 +3815,11 @@
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
     },
+    "hosted-git-info": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+    },
     "htmlescape": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
@@ -3770,6 +3905,14 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "requires": {
+        "repeating": "2.0.1"
+      }
+    },
     "indexof": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
@@ -3780,7 +3923,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -3848,6 +3990,11 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
       "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA="
     },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+    },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -3862,6 +4009,14 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
       "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -3889,6 +4044,14 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -3928,6 +4091,11 @@
       "requires": {
         "kind-of": "3.2.2"
       }
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -3991,6 +4159,11 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-wsl": {
       "version": "1.1.0",
@@ -4631,6 +4804,24 @@
         "immediate": "3.0.6"
       }
     },
+    "lighthouse-logger": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.0.1.tgz",
+      "integrity": "sha1-8HPYP3rLyWcpvxAKEhyPAGmRrmE=",
+      "requires": {
+        "debug": "2.6.8"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "live-server": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/live-server/-/live-server-1.2.0.tgz",
@@ -4740,6 +4931,28 @@
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "dev": true
             }
+          }
+        }
+      }
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "requires": {
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -4871,6 +5084,11 @@
         }
       }
     },
+    "loglevel": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.4.1.tgz",
+      "integrity": "sha1-lbOD+Ro8J1b9SrCTZn5DCRYfK80="
+    },
     "lolex": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
@@ -4883,11 +5101,25 @@
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "requires": {
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
+      }
+    },
     "lru-cache": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
       "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=",
       "dev": true
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
     "map-stream": {
       "version": "0.1.0",
@@ -4921,6 +5153,23 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "requires": {
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
+      }
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -4997,7 +5246,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -5005,14 +5253,12 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -5020,8 +5266,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -5074,6 +5319,54 @@
           "dev": true,
           "requires": {
             "has-flag": "1.0.0"
+          }
+        }
+      }
+    },
+    "mocha-chrome": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/mocha-chrome/-/mocha-chrome-0.1.1.tgz",
+      "integrity": "sha1-D6AYf38HkKPFyPDE+Wh/h8dd9uY=",
+      "requires": {
+        "chalk": "2.1.0",
+        "chrome-launcher": "0.4.0",
+        "chrome-remote-interface": "0.24.4",
+        "chrome-unmirror": "0.1.0",
+        "deep-assign": "2.0.0",
+        "loglevel": "1.4.1",
+        "meow": "3.7.0",
+        "nanobus": "4.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.2.1"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "supports-color": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "requires": {
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -5147,6 +5440,23 @@
       "dev": true,
       "optional": true
     },
+    "nanobus": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/nanobus/-/nanobus-4.2.0.tgz",
+      "integrity": "sha1-T/6wNlsDPXp8xPDI7lyMGqmzK6w=",
+      "requires": {
+        "nanotiming": "6.1.3",
+        "remove-array-items": "1.0.0"
+      }
+    },
+    "nanotiming": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/nanotiming/-/nanotiming-6.1.3.tgz",
+      "integrity": "sha512-1PaTW4nyeYVKhPdydxl5u0tQn33C5Raf48lOKFKrKTUWmVlWdJkJKsqyYzGQ4jU43Da6NpyvAUzdZlfVs7RhPA==",
+      "requires": {
+        "on-idle": "3.1.2"
+      }
+    },
     "native-promise-only": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
@@ -5179,6 +5489,17 @@
         "abbrev": "1.0.9"
       }
     },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "4.3.6",
+        "validate-npm-package-license": "3.0.1"
+      }
+    },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -5202,8 +5523,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nyc": {
       "version": "10.3.2",
@@ -6609,8 +6929,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-component": {
       "version": "0.0.3",
@@ -6641,11 +6960,15 @@
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
       "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
     },
+    "on-idle": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/on-idle/-/on-idle-3.1.2.tgz",
+      "integrity": "sha512-NRB0PAuE8LvWBtaN5b65U/vEWVLQPqUfSDOK6gf5BgfXa2WelSopZj4NkSR0MoqYsk28ugYpcdDpaYANV2WKEA=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -6782,6 +7105,14 @@
         "is-glob": "2.0.1"
       }
     },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "requires": {
+        "error-ex": "1.3.1"
+      }
+    },
     "parsejson": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
@@ -6853,11 +7184,18 @@
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
     },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -6881,6 +7219,16 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "pause": {
       "version": "0.0.1",
@@ -6958,20 +7306,17 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
       "requires": {
         "pinkie": "2.0.4"
       }
@@ -7148,6 +7493,25 @@
         "readable-stream": "2.3.3"
       }
     },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "requires": {
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "requires": {
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      }
+    },
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
@@ -7195,6 +7559,15 @@
         "resolve": "1.4.0"
       }
     },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "requires": {
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
+      }
+    },
     "redis": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
@@ -7225,6 +7598,11 @@
         "is-primitive": "2.0.0"
       }
     },
+    "remove-array-items": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.0.0.tgz",
+      "integrity": "sha1-B79CyzMvTPboXq2DteToltIyayE="
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -7242,6 +7620,14 @@
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "requires": {
+        "is-finite": "1.0.2"
+      }
     },
     "request": {
       "version": "2.81.0",
@@ -7337,7 +7723,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true,
       "requires": {
         "glob": "7.1.2"
       }
@@ -7411,8 +7796,7 @@
     "semver": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-      "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-      "dev": true
+      "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
     },
     "send": {
       "version": "0.15.4",
@@ -7533,6 +7917,11 @@
         "interpret": "1.0.3",
         "rechoir": "0.6.2"
       }
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
       "version": "2.4.1",
@@ -7736,6 +8125,24 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+    },
     "split": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
@@ -7872,6 +8279,14 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "requires": {
+        "get-stdin": "4.0.1"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -8112,6 +8527,11 @@
         "punycode": "1.4.1"
       }
     },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+    },
     "tryit": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
@@ -8296,6 +8716,15 @@
       "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
       "dev": true
     },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
+    },
     "vary": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
@@ -8390,8 +8819,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "express": "^4.15.2",
     "express-session": "^1.15.2",
     "log": "^1.4.0",
+    "mocha-chrome": "^0.1.1",
     "morgan": "^1.8.1",
     "normalize.css": "^7.0.0",
     "passport": "^0.3.2",

--- a/scripts/test
+++ b/scripts/test
@@ -17,12 +17,6 @@ if [[ -z "$DISABLE_KARMA" ]] &&
   export DISABLE_KARMA='true'
 fi
 
-# Don't run Chrome on Travis CI due to the "Some of your tests did a full page
-# reload!" bug.
-if [[ "$CI" == 'true' ]]; then
-  export KARMA_BROWSERS=Firefox,PhantomJS
-fi
-
 _test_tab_completion() {
   local word_index="$1"
   shift

--- a/scripts/test.d/browser
+++ b/scripts/test.d/browser
@@ -54,7 +54,7 @@ _test_browser_run_tests() {
   fi
 
   if [[ "$__single_run" == 'true' ]]; then
-    _test_browser_run_in_phantomjs
+    _test_browser_run_in_headless_browsers
   else
     _test_browser_run_in_browser
   fi
@@ -69,12 +69,12 @@ _test_browser_run_in_browser() {
   live-server "${test_args[@]}" public/
 }
 
-_test_browser_run_in_phantomjs() {
+_test_browser_run_in_headless_browsers() {
   local port
   local test_server_url
   local sleep_seconds='1'
   local server_pid
-  local result
+  local result='0'
 
   port="$(tests/helpers/pick-unused-port)"
   if [[ "$?" -ne '0' ]]; then
@@ -97,14 +97,28 @@ _test_browser_run_in_phantomjs() {
   sleep "$sleep_seconds"
   server_pid="$!"
 
-  phantomjs node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js \
-    "$test_server_url/tests/" 'spec' "{ \"useColors\": true }"
-  result="$?"
+  if ! _test_browser_run_in_chrome_headless; then
+    result='1'
+  fi
+  if ! _test_browser_run_in_phantomjs; then
+    result='1'
+  fi
   _test_browser_download_coverage
 
   kill -INT "$server_pid"
   set +m
   return "$result"
+}
+
+_test_browser_run_in_chrome_headless() {
+  @go.log INFO 'Running browser tests in headless Chrome'
+  mocha-chrome --reporter spec "$test_server_url/tests/"
+}
+
+_test_browser_run_in_phantomjs() {
+  @go.log INFO 'Running browser tests in PhantomJS'
+  phantomjs node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js \
+    "$test_server_url/tests/" 'spec' "{ \"useColors\": true }"
 }
 
 _test_browser_download_coverage() {

--- a/scripts/test.d/browser
+++ b/scripts/test.d/browser
@@ -111,6 +111,23 @@ _test_browser_run_in_headless_browsers() {
 }
 
 _test_browser_run_in_chrome_headless() {
+  local node_version="$(node --version)"
+  local major_version
+  local minor_version
+  local patch_version
+
+  if [[ "$node_version" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+    major_version="${BASH_REMATCH[1]}"
+    minor_version="${BASH_REMATCH[2]}"
+    patch_version="${BASH_REMATCH[3]}"
+  fi
+
+  if [[ "$major_version" -lt '7' ||
+      ( "$major_version" -eq '7' && "$minor_version" -lt '10' ) ]]; then
+    @go.log INFO "Skipping headless Chrome run on Node ${node_version}," \
+      "since mocha-chrome isn't supported before v7.10.0."
+    return
+  fi
   @go.log INFO 'Running browser tests in headless Chrome'
   mocha-chrome --reporter spec "$test_server_url/tests/"
 }

--- a/tests/end-to-end/end-to-end.js
+++ b/tests/end-to-end/end-to-end.js
@@ -8,6 +8,7 @@ var chai = require('chai')
 var chaiAsPromised = require('chai-as-promised')
 var test = require('selenium-webdriver/testing')
 var webdriver = require('selenium-webdriver')
+var chrome = require('selenium-webdriver/chrome')
 var By = webdriver.By
 var Key = webdriver.Key
 var until = webdriver.until
@@ -32,9 +33,12 @@ test.describe('End-to-end test', function() {
   this.timeout(5000)
 
   test.before(function() {
-    driver = new webdriver.Builder()
-      .forBrowser('chrome')
-      .build()
+    driver = new webdriver.Builder().forBrowser('chrome')
+
+    if (process.env.CI) {
+      driver = driver.setChromeOptions(new chrome.Options().headless())
+    }
+    driver = driver.build()
 
     return helpers.launchAll().then(result => {
       serverInfo = result


### PR DESCRIPTION
Per:
* https://developers.google.com/web/updates/2017/04/headless-chrome
* https://developers.google.com/web/updates/2017/06/headless-karma-mocha-chai

Also keeping an eye on headless Firefox, which looks like it's coming soon:
* https://adriftwith.me/coding/2017/04/21/headless-slimerjs-with-firefox/

Once that's available, we can drop `xvfb` from `.travis.yml`.

Also includes updates to package-lock.json and enables Karma to run Chrome on CI/Travis again. If the latter update breaks the build due to the "Some of your tests did a full page reload!" bug again, I'll revert that commit. 