### PR TITLE
config: Convert users and domains to lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ following required fields:
 You must also provide at least one of the following fields:
 
 * **users**: A list of specific user account names (usually email addresses)
-  that are authorized to access the server.
+  that are authorized to access the server. (Case insensitive)
 * **domains**: A list of user domains (i.e. email address domains) that are
-  authorized to access the server.
+  authorized to access the server. (Case insensitive)
 
 You may define both of these fields if you wish.
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -12,12 +12,24 @@ function Config(configData) {
         REDIS_PORT: true
       }
 
+
   applyEnvUpdates(configData)
   validateConfig(configData)
+  setItemsToLowerCase(configData, ['users', 'domains'])
 
   Object.keys(configData).forEach(key => {
     var value = configData[key]
     config[key] = numericValues[key] ? parseInt(value) : value
+  })
+}
+
+function setItemsToLowerCase(configData, properties) {
+  properties.forEach(prop => {
+    var items = configData[prop]
+
+    if (items !== undefined) {
+      configData[prop] = items.map(item => item.toLowerCase())
+    }
   })
 }
 

--- a/tests/server/config-test.js
+++ b/tests/server/config-test.js
@@ -31,6 +31,17 @@ describe('config', function() {
     expect(JSON.stringify(config)).to.equal(JSON.stringify(configData))
   })
 
+  it('converts users and domains to lowercase', function() {
+    var configData = helpers.baseConfig(),
+        config
+
+    configData.users = ['MBland@acm.org']
+    configData.domains = ['ACM.org']
+    config = new Config(configData)
+    expect(config.users).to.eql(['mbland@acm.org'])
+    expect(config.domains).to.eql(['acm.org'])
+  })
+
   it('raises errors for missing fields', function() {
     var errors = [
       'missing PORT',


### PR DESCRIPTION
In addition to converting authenticated user IDs to lowercase in #155 and #156, it seems prudent to ensure that configured user IDs and domains are all forced to lowercase as well, to adhere to the principle of least surprise.