### PR TITLE
redis: Add link, target completion & target search

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ var redisClient = redis.createClient(redisClientOptions)
 app.use(morgan('combined'))
 customLinks.assembleApp(
   app,
-  new LinkDb(new RedisClient(redisClient)),
+  new LinkDb(new RedisClient(redisClient, config)),
   log,
   new RedisStore(redisStoreOptions),
   config)

--- a/lib/config.js
+++ b/lib/config.js
@@ -9,7 +9,8 @@ function Config(configData) {
       numericValues = {
         PORT: true,
         SESSION_MAX_AGE: true,
-        REDIS_PORT: true
+        REDIS_PORT: true,
+        REDIS_RANGE_SIZE: true
       }
 
 
@@ -58,6 +59,7 @@ var schema = {
   },
   optionalTopLevelFields: {
     SESSION_MAX_AGE: 'maximum age of a session, in seconds',
+    REDIS_RANGE_SIZE: 'redis-server range scan result set size',
     REDIS_HOST: 'redis-server host',
     REDIS_PORT: 'redis-server port',
     users: 'list of authorized usernames (email addresses)',
@@ -85,7 +87,8 @@ function applyEnvUpdates(configData) {
     'SESSION_SECRET',
     'SESSION_MAX_AGE',
     'REDIS_HOST',
-    'REDIS_PORT'
+    'REDIS_PORT',
+    'REDIS_RANGE_SIZE'
   ]
 
   envProperties.forEach(assignEnvVarToConfigProperty(configData))

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -8,7 +8,6 @@ function key() {
 
 const SEARCH_LINKS_KEY = key('search', 'links')
 const SEARCH_TARGETS_KEY = key('search', 'targets')
-const MAX_COMPLETIONS = 10
 
 function targetLinksKey(target) {
   return key('target', target)
@@ -191,21 +190,38 @@ RedisClient.prototype.completeTarget = function(prefix) {
 // http://oldblog.antirez.com/post/autocomplete-with-redis.html
 function completeString(client, setName, prefix) {
   var getRank,
-      getRange
+      startRank,
+      getRange,
+      collectResults,
+      results = []
+  const rangeSize = 25
 
   getRank = () => new Promise((resolve, reject) => {
     client.zrank(setName, prefix, promiseDone(resolve, reject))
   })
-  getRange = (rank) => new Promise((resolve, reject) => {
-    client.zrange(setName, rank + 1, -1, promiseDone(resolve, reject))
+  getRange = () => new Promise((resolve, reject) => {
+    if (startRank === null) {
+      return resolve([])
+    }
+    client.zrange(setName, startRank, startRank + rangeSize - 1,
+      promiseDone(resolve, reject))
   })
-  return getRank().then(getRange).then((results) => {
-    return results
-      .filter(result => result.substr(0, prefix.length) === prefix)
-      .filter(result => result.substr(result.length - 1) === '*')
-      .map(result => result.substr(0, result.length - 1))
-      .slice(0, MAX_COMPLETIONS)
-  })
+  collectResults = range => {
+    range.filter(i => i.substr(i.length - 1) === '*')
+      .filter(i => i.substr(0, prefix.length) === prefix)
+      .forEach(i => results.push(i.substr(0, i.length - 1)))
+
+    if (range.length < rangeSize ||
+        range[range.length - 1].substr(0, prefix.length) !== prefix) {
+      return results
+    }
+    startRank += rangeSize
+    return getRange().then(collectResults)
+  }
+  return getRank()
+    .then(rank => startRank = rank)
+    .then(getRange)
+    .then(collectResults)
 }
 
 RedisClient.prototype.getLinksToTarget = function(target) {

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -133,6 +133,8 @@ RedisClient.prototype.createLink = function(link, target, owner) {
             return reject(new Error(link + ' created, ' +
               'but failed to set target, clicks, and timestamps: ' + err))
           }
+          // Note we resolve to the resulting Error if the search set insert
+          // fails, since the link actually exists.
           addLinkToSearchSets(this.impl, link, target)
             .then(() => resolve(true))
             .catch(resolve)
@@ -141,17 +143,17 @@ RedisClient.prototype.createLink = function(link, target, owner) {
   })
 }
 
-function addLinkToSearchSets(client, link, target) {
+function addLinkToSearchSets(clientImpl, link, target) {
   return Promise.all([
     // Don't store the leading `/` in our link keys.
-    addPrefixesToSearchSet(client, SEARCH_LINKS_KEY, link.slice(1)),
-    addLinkToTargetList(client, target, link)
+    addPrefixesToSearchSet(clientImpl, SEARCH_LINKS_KEY, link.slice(1)),
+    addLinkToTargetList(clientImpl, target, link)
   ])
 }
 
 // This builds a sorted set of words and their prefixes per:
 // http://oldblog.antirez.com/post/autocomplete-with-redis.html
-function addPrefixesToSearchSet(client, setName, value) {
+function addPrefixesToSearchSet(clientImpl, setName, value) {
   return new Promise((resolve, reject) => {
     var args = [setName],
         endIndex = value.length + 1,
@@ -164,13 +166,13 @@ function addPrefixesToSearchSet(client, setName, value) {
     args.push(0)
     args.push(value + '*')
     args.push(promiseDone(resolve, reject))
-    client.zadd.apply(client, args)
+    clientImpl.zadd.apply(clientImpl, args)
   })
 }
 
-function addLinkToTargetList(client, target, link) {
+function addLinkToTargetList(clientImpl, target, link) {
   return new Promise((resolve, reject) => {
-    client.lpush(targetLinksKey(target), link, promiseDone(resolve, reject))
+    clientImpl.lpush(targetLinksKey(target), link, promiseDone(resolve, reject))
   })
 }
 

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -7,7 +7,6 @@ function key() {
 }
 
 const SEARCH_LINKS_KEY = key('search', 'links')
-const SEARCH_TARGETS_KEY = key('search', 'targets')
 
 function targetLinksKey(target) {
   return key('target', target)
@@ -146,7 +145,6 @@ function addLinkToSearchSets(client, link, target) {
   return Promise.all([
     // Don't store the leading `/` in our link keys.
     addPrefixesToSearchSet(client, SEARCH_LINKS_KEY, link.slice(1)),
-    addPrefixesToSearchSet(client, SEARCH_TARGETS_KEY, target),
     addLinkToTargetList(client, target, link)
   ])
 }
@@ -178,15 +176,9 @@ function addLinkToTargetList(client, target, link) {
 
 RedisClient.prototype.completeLink = function(prefix) {
   const MIN_LINK_PREFIX_SIZE = 3
+
   return prefix.length < MIN_LINK_PREFIX_SIZE ? Promise.resolve([]) :
     completeString(this, SEARCH_LINKS_KEY, prefix)
-}
-
-RedisClient.prototype.completeTarget = function(prefix) {
-  if (prefix.length < 7 || prefix === 'http://' || prefix === 'https://') {
-    return Promise.resolve([])
-  }
-  return completeString(this, SEARCH_TARGETS_KEY, prefix)
 }
 
 // Returns the completed words indexed by addPrefixesToSearchSet() per:

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -8,7 +8,6 @@ function key() {
 
 const SEARCH_LINKS_KEY = key('search', 'links')
 const SEARCH_TARGETS_KEY = key('search', 'targets')
-const SEARCH_RANGE_SIZE = 25
 
 function targetLinksKey(target) {
   return key('target', target)
@@ -18,8 +17,9 @@ function promiseDone(resolve, reject) {
   return (err, result) => err ? reject(err) : resolve(result)
 }
 
-function RedisClient(client, getTimestamp) {
+function RedisClient(client, config, getTimestamp) {
   this.client = client
+  this.rangeSize = (config || {}).REDIS_RANGE_SIZE || 25
   this.getTimestamp = getTimestamp || (() => new Date().getTime())
 }
 
@@ -177,22 +177,23 @@ function addLinkToTargetList(client, target, link) {
 }
 
 RedisClient.prototype.completeLink = function(prefix) {
-  return completeString(this.client, SEARCH_LINKS_KEY, prefix)
+  return completeString(this, SEARCH_LINKS_KEY, prefix)
 }
 
 RedisClient.prototype.completeTarget = function(prefix) {
   if (prefix.length < 7 || prefix === 'http://' || prefix === 'https://') {
     return Promise.resolve([])
   }
-  return completeString(this.client, SEARCH_TARGETS_KEY, prefix)
+  return completeString(this, SEARCH_TARGETS_KEY, prefix)
 }
-
 
 // Returns the completed words indexed by addPrefixesToSearchSet() per:
 // http://oldblog.antirez.com/post/autocomplete-with-redis.html
 function completeString(client, setName, prefix) {
-  var startRank,
-      getRange = getSearchPrefixRange(client, setName),
+  const rangeSize = client.rangeSize
+  var externalClient = client.client,
+      startRank,
+      getRange = getSearchPrefixRange(externalClient, setName, rangeSize),
       collectResults,
       results = []
 
@@ -201,31 +202,31 @@ function completeString(client, setName, prefix) {
       .filter(i => i.substr(0, prefix.length) === prefix)
       .forEach(i => results.push(i.substr(0, i.length - 1)))
 
-    if (range.length < SEARCH_RANGE_SIZE ||
+    if (range.length < rangeSize ||
         range[range.length - 1].substr(0, prefix.length) !== prefix) {
       return results
     }
-    startRank += SEARCH_RANGE_SIZE
+    startRank += rangeSize
     return getRange(startRank).then(collectResults)
   }
-  return getSearchPrefixRank(client, setName, prefix)
+  return getSearchPrefixRank(externalClient, setName, prefix)
     .then(rank => startRank = rank)
     .then(getRange)
     .then(collectResults)
 }
 
-function getSearchPrefixRank(client, setName, prefix) {
+function getSearchPrefixRank(externalClient, setName, prefix) {
   return new Promise((resolve, reject) => {
-    client.zrank(setName, prefix, promiseDone(resolve, reject))
+    externalClient.zrank(setName, prefix, promiseDone(resolve, reject))
   })
 }
 
-function getSearchPrefixRange(client, setName) {
+function getSearchPrefixRange(externalClient, setName, rangeSize) {
   return startRank => new Promise((resolve, reject) => {
     if (startRank === null) {
       return resolve([])
     }
-    client.zrange(setName, startRank, startRank + SEARCH_RANGE_SIZE - 1,
+    externalClient.zrange(setName, startRank, startRank + rangeSize - 1,
       promiseDone(resolve, reject))
   })
 }

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -177,7 +177,9 @@ function addLinkToTargetList(client, target, link) {
 }
 
 RedisClient.prototype.completeLink = function(prefix) {
-  return completeString(this, SEARCH_LINKS_KEY, prefix)
+  const MIN_LINK_PREFIX_SIZE = 3
+  return prefix.length < MIN_LINK_PREFIX_SIZE ? Promise.resolve([]) :
+    completeString(this, SEARCH_LINKS_KEY, prefix)
 }
 
 RedisClient.prototype.completeTarget = function(prefix) {

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -134,23 +134,21 @@ RedisClient.prototype.createLink = function(link, target, owner) {
             return reject(new Error(link + ' created, ' +
               'but failed to set target, clicks, and timestamps: ' + err))
           }
-          addLinkToSearchSets(this.client, link, target, resolve, reject)
+          addLinkToSearchSets(this.client, link, target)
+            .then(() => resolve(true))
+            .catch(err => reject(err))
         })
     })
   })
 }
 
-function addLinkToSearchSets(client, link, target, resolve, reject) {
-  var ops = [
+function addLinkToSearchSets(client, link, target) {
+  return Promise.all([
     // Don't store the leading `/` in our link keys.
     addPrefixesToSearchSet(client, SEARCH_LINKS_KEY, link.slice(1)),
     addPrefixesToSearchSet(client, SEARCH_TARGETS_KEY, target),
     addLinkToTargetList(client, target, link)
-  ]
-
-  Promise.all(ops)
-    .then(() => resolve(true))
-    .catch(err => reject(err))
+  ])
 }
 
 // This builds a sorted set of words and their prefixes per:

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -2,6 +2,22 @@
 
 module.exports = RedisClient
 
+function key() {
+  return Array.prototype.slice.call(arguments).join(':')
+}
+
+const SEARCH_LINKS_KEY = key('search', 'links')
+const SEARCH_TARGETS_KEY = key('search', 'targets')
+const MAX_COMPLETIONS = 10
+
+function targetLinksKey(target) {
+  return key('target', target)
+}
+
+function promiseDone(resolve, reject) {
+  return (err, result) => err ? reject(err) : resolve(result)
+}
+
 function RedisClient(client, getTimestamp) {
   this.client = client
   this.getTimestamp = getTimestamp || (() => new Date().getTime())
@@ -23,7 +39,7 @@ class SearchHelper {
 
   processResults(resolve, reject) {
     this.redisClient.scan(this.cursor, 'match', this.regExp,
-      (err, results) => err ? reject(err) : resolve(results))
+      promiseDone(resolve, reject))
   }
 
   scan() {
@@ -77,7 +93,7 @@ RedisClient.prototype.getLink = function(link) {
 
 RedisClient.prototype.getLinks = function(searchString) {
   var searchHelper = new SearchHelper(this.client, searchString)
-  return searchHelper.scan().then(links => this.fetchLinkData(links))
+  return searchHelper.scan().then(links => this.fetchLinkData(links.sort()))
 }
 
 RedisClient.prototype.recordAccess = function(link) {
@@ -118,10 +134,89 @@ RedisClient.prototype.createLink = function(link, target, owner) {
             return reject(new Error(link + ' created, ' +
               'but failed to set target, clicks, and timestamps: ' + err))
           }
-          resolve(true)
+          addLinkToSearchSets(this.client, link, target, resolve, reject)
         })
     })
   })
+}
+
+function addLinkToSearchSets(client, link, target, resolve, reject) {
+  var ops = [
+    // Don't store the leading `/` in our link keys.
+    addPrefixesToSearchSet(client, SEARCH_LINKS_KEY, link.slice(1)),
+    addPrefixesToSearchSet(client, SEARCH_TARGETS_KEY, target),
+    addLinkToTargetList(client, target, link)
+  ]
+
+  Promise.all(ops)
+    .then(() => resolve(true))
+    .catch(err => reject(err))
+}
+
+// This builds a sorted set of words and their prefixes per:
+// http://oldblog.antirez.com/post/autocomplete-with-redis.html
+function addPrefixesToSearchSet(client, setName, value) {
+  return new Promise((resolve, reject) => {
+    var args = [setName],
+        i
+
+    for (i = 1; i != value.length; ++i) {
+      args.push(0)
+      args.push(value.slice(0, i))
+    }
+    args.push(0)
+    args.push(value + '*')
+    args.push(promiseDone(resolve, reject))
+    client.zadd.apply(client, args)
+  })
+}
+
+function addLinkToTargetList(client, target, link) {
+  return new Promise((resolve, reject) => {
+    client.lpush(targetLinksKey(target), link, promiseDone(resolve, reject))
+  })
+}
+
+RedisClient.prototype.completeLink = function(prefix) {
+  return completeString(this.client, SEARCH_LINKS_KEY, prefix)
+}
+
+RedisClient.prototype.completeTarget = function(prefix) {
+  if (prefix.length < 7 || prefix === 'http://' || prefix === 'https://') {
+    return Promise.resolve([])
+  }
+  return completeString(this.client, SEARCH_TARGETS_KEY, prefix)
+}
+
+// Returns the completed words indexed by addPrefixesToSearchSet() per:
+// http://oldblog.antirez.com/post/autocomplete-with-redis.html
+function completeString(client, setName, prefix) {
+  var getRank,
+      getRange
+
+  getRank = () => new Promise((resolve, reject) => {
+    client.zrank(setName, prefix, promiseDone(resolve, reject))
+  })
+  getRange = (rank) => new Promise((resolve, reject) => {
+    client.zrange(setName, rank + 1, -1, promiseDone(resolve, reject))
+  })
+  return getRank().then(getRange).then((results) => {
+    return results
+      .filter(result => result.substr(0, prefix.length) === prefix)
+      .filter(result => result.substr(result.length - 1) === '*')
+      .map(result => result.substr(0, result.length - 1))
+      .slice(0, MAX_COMPLETIONS)
+  })
+}
+
+RedisClient.prototype.getLinksToTarget = function(target) {
+  var getTargetLinks
+
+  getTargetLinks = () => new Promise((resolve, reject) => {
+    this.client.lrange(targetLinksKey(target), 0, -1,
+      promiseDone(resolve, reject))
+  })
+  return getTargetLinks().then(links => links.sort())
 }
 
 RedisClient.prototype.getOwnedLinks = function(owner) {

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -16,8 +16,8 @@ function promiseDone(resolve, reject) {
   return (err, result) => err ? reject(err) : resolve(result)
 }
 
-function RedisClient(client, config, getTimestamp) {
-  this.client = client
+function RedisClient(clientImpl, config, getTimestamp) {
+  this.impl = clientImpl
   this.rangeSize = (config || {}).REDIS_RANGE_SIZE || 25
   this.getTimestamp = getTimestamp || (() => new Date().getTime())
 }
@@ -64,7 +64,7 @@ function expectResult(expected, func) {
 }
 
 RedisClient.prototype.userExists = function(userId) {
-  return expectResult(1, done => this.client.exists(userId, done))
+  return expectResult(1, done => this.impl.exists(userId, done))
 }
 
 RedisClient.prototype.findOrCreateUser = function(userId) {
@@ -73,13 +73,13 @@ RedisClient.prototype.findOrCreateUser = function(userId) {
       if (exists) {
         return false
       }
-      return expectResult(1, done => this.client.lpush(userId, '', done))
+      return expectResult(1, done => this.impl.lpush(userId, '', done))
     })
 }
 
 RedisClient.prototype.getLink = function(link) {
   return new Promise((resolve, reject) => {
-    this.client.hgetall(link, (err, linkData) => {
+    this.impl.hgetall(link, (err, linkData) => {
       if (err) {
         return reject(err)
       } else if (linkData && linkData.clicks) {
@@ -91,39 +91,39 @@ RedisClient.prototype.getLink = function(link) {
 }
 
 RedisClient.prototype.getLinks = function(searchString) {
-  var searchHelper = new SearchHelper(this.client, searchString)
+  var searchHelper = new SearchHelper(this.impl, searchString)
   return searchHelper.scan().then(links => this.fetchLinkData(links.sort()))
 }
 
 RedisClient.prototype.recordAccess = function(link) {
   return new Promise((resolve, reject) => {
-    this.client.hincrby(link, 'clicks', 1, err => err ? reject(err) : resolve())
+    this.impl.hincrby(link, 'clicks', 1, err => err ? reject(err) : resolve())
   })
 }
 
 RedisClient.prototype.addLinkToOwner = function(owner, link) {
   return new Promise((resolve, reject) => {
-    this.client.lpushx(owner, link, (err, result) => {
+    this.impl.lpushx(owner, link, (err, result) => {
       err ? reject(err) : resolve(result !== 0)
     })
   })
 }
 
 RedisClient.prototype.removeLinkFromOwner = function(owner, link) {
-  return expectResult(1, done => this.client.lrem(owner, 1, link, done))
+  return expectResult(1, done => this.impl.lrem(owner, 1, link, done))
 }
 
 RedisClient.prototype.createLink = function(link, target, owner) {
   return new Promise((resolve, reject) => {
     var createdStamp = this.getTimestamp()
 
-    this.client.hsetnx(link, 'owner', owner, (err, result) => {
+    this.impl.hsetnx(link, 'owner', owner, (err, result) => {
       if (err) {
         return reject(err)
       } else if (result === 0) {
         return resolve(false)
       }
-      this.client.hmset(link,
+      this.impl.hmset(link,
         'target', target,
         'created', createdStamp,
         'updated', createdStamp,
@@ -133,7 +133,7 @@ RedisClient.prototype.createLink = function(link, target, owner) {
             return reject(new Error(link + ' created, ' +
               'but failed to set target, clicks, and timestamps: ' + err))
           }
-          addLinkToSearchSets(this.client, link, target)
+          addLinkToSearchSets(this.impl, link, target)
             .then(() => resolve(true))
             .catch(err => reject(err))
         })
@@ -185,9 +185,8 @@ RedisClient.prototype.completeLink = function(prefix) {
 // http://oldblog.antirez.com/post/autocomplete-with-redis.html
 function completeString(client, setName, prefix) {
   const rangeSize = client.rangeSize
-  var externalClient = client.client,
-      startRank,
-      getRange = getSearchPrefixRange(externalClient, setName, rangeSize),
+  var startRank,
+      getRange = getSearchPrefixRange(client.impl, setName, rangeSize),
       collectResults,
       results = []
 
@@ -203,24 +202,24 @@ function completeString(client, setName, prefix) {
     startRank += rangeSize
     return getRange(startRank).then(collectResults)
   }
-  return getSearchPrefixRank(externalClient, setName, prefix)
+  return getSearchPrefixRank(client.impl, setName, prefix)
     .then(rank => startRank = rank)
     .then(getRange)
     .then(collectResults)
 }
 
-function getSearchPrefixRank(externalClient, setName, prefix) {
+function getSearchPrefixRank(clientImpl, setName, prefix) {
   return new Promise((resolve, reject) => {
-    externalClient.zrank(setName, prefix, promiseDone(resolve, reject))
+    clientImpl.zrank(setName, prefix, promiseDone(resolve, reject))
   })
 }
 
-function getSearchPrefixRange(externalClient, setName, rangeSize) {
+function getSearchPrefixRange(clientImpl, setName, rangeSize) {
   return startRank => new Promise((resolve, reject) => {
     if (startRank === null) {
       return resolve([])
     }
-    externalClient.zrange(setName, startRank, startRank + rangeSize - 1,
+    clientImpl.zrange(setName, startRank, startRank + rangeSize - 1,
       promiseDone(resolve, reject))
   })
 }
@@ -229,7 +228,7 @@ RedisClient.prototype.getLinksToTarget = function(target) {
   var getTargetLinks
 
   getTargetLinks = () => new Promise((resolve, reject) => {
-    this.client.lrange(targetLinksKey(target), 0, -1,
+    this.impl.lrange(targetLinksKey(target), 0, -1,
       promiseDone(resolve, reject))
   })
   return getTargetLinks().then(links => links.sort())
@@ -237,7 +236,7 @@ RedisClient.prototype.getLinksToTarget = function(target) {
 
 RedisClient.prototype.getOwnedLinks = function(owner) {
   return new Promise((resolve, reject) => {
-    this.client.lrange(owner, 0, -1, (err, data) => {
+    this.impl.lrange(owner, 0, -1, (err, data) => {
       if (err) {
         return reject(err)
       }
@@ -256,7 +255,7 @@ RedisClient.prototype.updateProperty = function(link, property, value) {
         return Promise.resolve(false)
       }
       return expectResult('OK', done => {
-        this.client.hmset(link,
+        this.impl.hmset(link,
           property, value,
           'updated', this.getTimestamp(),
           done)
@@ -265,5 +264,5 @@ RedisClient.prototype.updateProperty = function(link, property, value) {
 }
 
 RedisClient.prototype.deleteLink = function(link) {
-  return expectResult(1, done => this.client.del(link, done))
+  return expectResult(1, done => this.impl.del(link, done))
 }

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -135,7 +135,7 @@ RedisClient.prototype.createLink = function(link, target, owner) {
           }
           addLinkToSearchSets(this.impl, link, target)
             .then(() => resolve(true))
-            .catch(err => reject(err))
+            .catch(resolve)
         })
     })
   })

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -156,9 +156,10 @@ function addLinkToSearchSets(client, link, target) {
 function addPrefixesToSearchSet(client, setName, value) {
   return new Promise((resolve, reject) => {
     var args = [setName],
+        endIndex = value.length + 1,
         i
 
-    for (i = 1; i != value.length; ++i) {
+    for (i = 1; i != endIndex; ++i) {
       args.push(0)
       args.push(value.slice(0, i))
     }

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -8,6 +8,7 @@ function key() {
 
 const SEARCH_LINKS_KEY = key('search', 'links')
 const SEARCH_TARGETS_KEY = key('search', 'targets')
+const SEARCH_RANGE_SIZE = 25
 
 function targetLinksKey(target) {
   return key('target', target)
@@ -186,42 +187,47 @@ RedisClient.prototype.completeTarget = function(prefix) {
   return completeString(this.client, SEARCH_TARGETS_KEY, prefix)
 }
 
+
 // Returns the completed words indexed by addPrefixesToSearchSet() per:
 // http://oldblog.antirez.com/post/autocomplete-with-redis.html
 function completeString(client, setName, prefix) {
-  var getRank,
-      startRank,
-      getRange,
+  var startRank,
+      getRange = getSearchPrefixRange(client, setName),
       collectResults,
       results = []
-  const rangeSize = 25
 
-  getRank = () => new Promise((resolve, reject) => {
-    client.zrank(setName, prefix, promiseDone(resolve, reject))
-  })
-  getRange = () => new Promise((resolve, reject) => {
-    if (startRank === null) {
-      return resolve([])
-    }
-    client.zrange(setName, startRank, startRank + rangeSize - 1,
-      promiseDone(resolve, reject))
-  })
   collectResults = range => {
     range.filter(i => i.substr(i.length - 1) === '*')
       .filter(i => i.substr(0, prefix.length) === prefix)
       .forEach(i => results.push(i.substr(0, i.length - 1)))
 
-    if (range.length < rangeSize ||
+    if (range.length < SEARCH_RANGE_SIZE ||
         range[range.length - 1].substr(0, prefix.length) !== prefix) {
       return results
     }
-    startRank += rangeSize
-    return getRange().then(collectResults)
+    startRank += SEARCH_RANGE_SIZE
+    return getRange(startRank).then(collectResults)
   }
-  return getRank()
+  return getSearchPrefixRank(client, setName, prefix)
     .then(rank => startRank = rank)
     .then(getRange)
     .then(collectResults)
+}
+
+function getSearchPrefixRank(client, setName, prefix) {
+  return new Promise((resolve, reject) => {
+    client.zrank(setName, prefix, promiseDone(resolve, reject))
+  })
+}
+
+function getSearchPrefixRange(client, setName) {
+  return startRank => new Promise((resolve, reject) => {
+    if (startRank === null) {
+      return resolve([])
+    }
+    client.zrange(setName, startRank, startRank + SEARCH_RANGE_SIZE - 1,
+      promiseDone(resolve, reject))
+  })
 }
 
 RedisClient.prototype.getLinksToTarget = function(target) {

--- a/tests/end-to-end/end-to-end.js
+++ b/tests/end-to-end/end-to-end.js
@@ -60,7 +60,7 @@ test.describe('End-to-end test', function() {
 
   test.afterEach(function() {
     return new Promise(function(resolve, reject) {
-      redisClient.client.flushdb(err => err ? reject(err) : resolve())
+      redisClient.impl.flushdb(err => err ? reject(err) : resolve())
     })
   })
 

--- a/tests/server/config-test.js
+++ b/tests/server/config-test.js
@@ -102,6 +102,7 @@ describe('config', function() {
           'SESSION_MAX_AGE',
           'REDIS_HOST',
           'REDIS_PORT',
+          'REDIS_RANGE_SIZE',
           'GOOGLE_CLIENT_ID',
           'GOOGLE_CLIENT_SECRET',
           'GOOGLE_CALLBACK_URL'
@@ -110,6 +111,7 @@ describe('config', function() {
 
     inputConfig.REDIS_HOST = compareConfig.REDIS_HOST = 'redis'
     inputConfig.REDIS_PORT = compareConfig.REDIS_PORT = 666
+    inputConfig.REDIS_RANGE_SIZE = compareConfig.REDIS_RANGE_SIZE = 27
 
     properties.forEach(function(name) {
       var value = inputConfig[name]
@@ -128,6 +130,8 @@ describe('config', function() {
       .to.equal(compareConfig.REDIS_HOST)
     expect(config.REDIS_PORT)
       .to.equal(compareConfig.REDIS_PORT)
+    expect(config.REDIS_AUTOCOMPLETE_SIZE)
+      .to.equal(compareConfig.REDIS_AUTOCOMPLETE_SIZE)
     expect(config.GOOGLE_CLIENT_ID)
       .to.equal(compareConfig.GOOGLE_CLIENT_ID)
     expect(config.GOOGLE_CLIENT_SECRET)

--- a/tests/server/redis-client-test.js
+++ b/tests/server/redis-client-test.js
@@ -472,43 +472,6 @@ describe('RedisClient', function() {
     })
   })
 
-  describe('completeTarget', function() {
-    beforeEach(function() {
-      return Promise.all([
-        redisClient.createLink('/foo', 'https://quux.com/', 'mbland'),
-        redisClient.createLink('/bar', 'https://quux.com/xyzzy', 'mbland'),
-        redisClient.createLink('/baz', 'https://plugh.com/', 'mbland')
-      ])
-    })
-
-    it('should complete the appropriate targets', function() {
-      return redisClient.completeTarget('https://q')
-        .should.be.fulfilled.then(targets => {
-          targets.should.eql(['https://quux.com/', 'https://quux.com/xyzzy'])
-        })
-    })
-
-    it('should return nothing if the target doesn\'t exist', function() {
-      return redisClient.completeTarget('https://nonexistent.com/')
-        .should.be.fulfilled.then(targets => targets.should.be.empty)
-    })
-
-    it ('should return nothing if the prefix is under 7 chars', function() {
-      return redisClient.completeTarget('http:/')
-        .should.be.fulfilled.then(targets => targets.should.be.empty)
-    })
-
-    it ('should return nothing if the prefix is http://', function() {
-      return redisClient.completeTarget('http://')
-        .should.be.fulfilled.then(targets => targets.should.be.empty)
-    })
-
-    it ('should return nothing if the prefix is https://', function() {
-      return redisClient.completeTarget('https://')
-        .should.be.fulfilled.then(targets => targets.should.be.empty)
-    })
-  })
-
   describe('getLinksToTarget', function() {
     beforeEach(function() {
       return Promise.all([

--- a/tests/server/redis-client-test.js
+++ b/tests/server/redis-client-test.js
@@ -17,6 +17,7 @@ describe('RedisClient', function() {
       stubClientImplMethod, fakeTimestamp, getFakeTimestamp, stubs
 
   before(function() {
+    var config = { REDIS_RANGE_SIZE: 2 }
     return helpers.pickUnusedPort()
       .then(helpers.launchRedis)
       .then(function(redisData) {
@@ -24,7 +25,7 @@ describe('RedisClient', function() {
         redisServer = redisData.server
         clientImpl = redis.createClient({ port: serverPort })
         getFakeTimestamp = () => new Date(parseInt(fakeTimestamp)).getTime()
-        redisClient = new RedisClient(clientImpl, getFakeTimestamp)
+        redisClient = new RedisClient(clientImpl, config, getFakeTimestamp)
       })
   })
 
@@ -82,7 +83,7 @@ describe('RedisClient', function() {
 
     it('uses the Date builtin in production', function() {
       var before = new Date().getTime(),
-          prodTime = new RedisClient(clientImpl).getTimestamp()
+          prodTime = new RedisClient(clientImpl, {}).getTimestamp()
 
       prodTime.should.be.within(before, new Date().getTime())
     })

--- a/tests/server/redis-client-test.js
+++ b/tests/server/redis-client-test.js
@@ -444,27 +444,36 @@ describe('RedisClient', function() {
   })
 
   describe('completeLink', function() {
-    before(function() {
+    beforeEach(function() {
       return Promise.all([
-        redisClient.createLink('/foo', LINK_TARGET, 'mbland'),
+        redisClient.createLink('/foobar', LINK_TARGET, 'mbland'),
         redisClient.createLink('/bar', LINK_TARGET, 'mbland'),
+        redisClient.createLink('/barbaz', LINK_TARGET, 'mbland'),
+        redisClient.createLink('/barquux', LINK_TARGET, 'mbland'),
         redisClient.createLink('/baz', LINK_TARGET, 'mbland')
       ])
     })
 
     it('should complete the appropriate links', function() {
-      return redisClient.completeLink('b')
-        .should.be.fulfilled.then(links => links.should.eql(['bar', 'baz']))
+      return redisClient.completeLink('bar')
+        .should.be.fulfilled.then(links => {
+          links.should.eql(['bar', 'barbaz', 'barquux'])
+        })
+    })
+
+    it('should complete nothing if prefix.length < 3', function() {
+      return redisClient.completeLink('ba')
+        .should.be.fulfilled.then(links => links.should.be.empty)
     })
 
     it('should return nothing if no links start with the prefix', function() {
-      return redisClient.completeLink('bazquux')
+      return redisClient.completeLink('plugh')
         .should.be.fulfilled.then(links => links.should.be.empty)
     })
   })
 
   describe('completeTarget', function() {
-    before(function() {
+    beforeEach(function() {
       return Promise.all([
         redisClient.createLink('/foo', 'https://quux.com/', 'mbland'),
         redisClient.createLink('/bar', 'https://quux.com/xyzzy', 'mbland'),
@@ -501,7 +510,7 @@ describe('RedisClient', function() {
   })
 
   describe('getLinksToTarget', function() {
-    before(function() {
+    beforeEach(function() {
       return Promise.all([
         redisClient.createLink('/foo', LINK_TARGET, 'mbland'),
         redisClient.createLink('/bar', LINK_TARGET, 'mbland'),


### PR DESCRIPTION
Part of #160, #161, #165, and #166. Implements the RedisClient operations necessary to support these search, autocomplete, and target collision features.

Uses the lexicographic completion approach described in: http://oldblog.antirez.com/post/autocomplete-with-redis.html

Note that we'll need a migration script to create the new search indexes for existing installations.