### PR TITLE
Fix "bad Redis" failure case flakiness

### DIFF
--- a/tests/server/smoke-test.js
+++ b/tests/server/smoke-test.js
@@ -62,9 +62,13 @@ describe('Smoke test', function() {
       'missing AUTH_PROVIDERS')
   })
 
-  it('fails due to a bad redis host', function() {
-    process.env.CUSTOM_LINKS_REDIS_HOST = 'nonexistent-redis-host'
-    return doLaunch().should.be.rejectedWith(Error,
-      /Redis connection to nonexistent-redis-host:[0-9]+ failed/)
+  it('fails due to a bad redis connection', function() {
+    // Find an unused port so that the attempt to connect to Redis on that port
+    // fails. This is less flaky than using a bogus hostname, since some DNS
+    // providers may convert the failed name lookup into a search query (such as
+    // those provided by coffee shop WiFi).
+    return helpers.pickUnusedPort()
+      .then(port => helpers.launchServer(port, port))
+      .should.be.rejectedWith(Error, /Redis connection to [^ ]*:[0-9]+ failed/)
   })
 })


### PR DESCRIPTION
The previous implementation relied on failure due to a bad Redis host name. This worked most of the time, but while running the test suite in a coffee shop, this test case would timeout and leave a stale redis-server running in the background. Eventually I realized this was because the coffee shop DNS provider was converting failed name lookups to search queries.

This implementation instead relies on connecting to an unused port, and doesn't start a redis-server instance to begin with.

cc: @akashvbabu @mpdatx 