### PR TITLE
Deindex and reindex links

### DIFF
--- a/lib/link-db.js
+++ b/lib/link-db.js
@@ -53,7 +53,7 @@ LinkDb.prototype.createLink = function(link, target, user) {
     })
     .then(created => {
       if (created === false) {
-        return this.checkOwnership(link, user).then(function() {
+        return this.getLinkIfOwner(link, user).then(function() {
           return Promise.reject(link + ' already exists')
         })
       }
@@ -74,7 +74,7 @@ LinkDb.prototype.getOwnedLinks = function(user) {
     .then(links => this.client.fetchLinkData(links))
 }
 
-LinkDb.prototype.checkOwnership = function(link, user) {
+LinkDb.prototype.getLinkIfOwner = function(link, user) {
   return this.client.getLink(link)
     .then(linkData => {
       if (!linkData) {
@@ -86,7 +86,7 @@ LinkDb.prototype.checkOwnership = function(link, user) {
 }
 
 LinkDb.prototype.updateProperty = function(link, user, property, value) {
-  return this.checkOwnership(link, user)
+  return this.getLinkIfOwner(link, user)
     .then(() => {
       return this.client.updateProperty(link, property, value)
         .catch(rethrowError('failed to update ' + property + ' of ' + link +
@@ -103,7 +103,7 @@ LinkDb.prototype.updateProperty = function(link, user, property, value) {
 LinkDb.prototype.changeOwner = function(link, user, newOwner) {
   return Promise.all(
     [
-      this.checkOwnership(link, user),
+      this.getLinkIfOwner(link, user),
       this.userExists(newOwner)
     ])
     .then(() => this.updateProperty(link, user, 'owner', newOwner))
@@ -133,7 +133,7 @@ LinkDb.prototype.updateTarget = function(link, user, newTarget) {
 }
 
 LinkDb.prototype.deleteLink = function(link, user) {
-  return this.checkOwnership(link, user)
+  return this.getLinkIfOwner(link, user)
     .then(() => {
       return this.client.deleteLink(link)
         .catch(rethrowError('failed to delete ' + link))

--- a/lib/link-db.js
+++ b/lib/link-db.js
@@ -82,6 +82,7 @@ LinkDb.prototype.getLinkIfOwner = function(link, user) {
       } else if (linkData.owner !== user) {
         return Promise.reject(link + ' is owned by ' + linkData.owner)
       }
+      return linkData
     })
 }
 

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -133,11 +133,7 @@ RedisClient.prototype.createLink = function(link, target, owner) {
             return reject(new Error(link + ' created, ' +
               'but failed to set target, clicks, and timestamps: ' + err))
           }
-          // Note we resolve to the resulting Error if the search set insert
-          // fails, since the link actually exists.
-          this.indexLink(link, target)
-            .then(() => resolve(true))
-            .catch(resolve)
+          resolve(true)
         })
     })
   })

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -2,14 +2,8 @@
 
 module.exports = RedisClient
 
-function key() {
+function redisKey() {
   return Array.prototype.slice.call(arguments).join(':')
-}
-
-const SEARCH_LINKS_KEY = key('search', 'links')
-
-function targetLinksKey(target) {
-  return key('target', target)
 }
 
 function promiseDone(resolve, reject) {
@@ -45,6 +39,122 @@ class SearchHelper {
     return new Promise((resolve, reject) => {
       this.processResults(resolve, reject)
     }).then(results => this.collectResults(results))
+  }
+}
+
+const SEARCH_LINKS_KEY = redisKey('search', 'links')
+
+class AutocompleteIndexer {
+  constructor(clientImpl) {
+    this.impl = clientImpl
+  }
+
+  // This builds a sorted set of words and their prefixes per:
+  // http://oldblog.antirez.com/post/autocomplete-with-redis.html
+  addLinkPrefixes(link) {
+    // Don't store the leading `/` in our link keys.
+    var value = link.slice(1)
+
+    return new Promise((resolve, reject) => {
+      var args = [SEARCH_LINKS_KEY],
+          endIndex = value.length + 1,
+          i
+
+      for (i = 1; i != endIndex; ++i) {
+        args.push(0)
+        args.push(value.slice(0, i))
+      }
+      args.push(0)
+      args.push(value + '*')
+      args.push(promiseDone(resolve, reject))
+      this.impl.zadd.apply(this.impl, args)
+    })
+  }
+
+  removeLink(link) {
+    return new Promise((resolve, reject) => {
+      // We don't store the leading `/` in our link keys.
+      this.impl.zrem(SEARCH_LINKS_KEY, link.slice(1) + '*',
+        promiseDone(resolve, reject))
+    })
+  }
+
+  // Returns the completed words indexed by addPrefixesToSearchSet() per:
+  // http://oldblog.antirez.com/post/autocomplete-with-redis.html
+  completeString(prefix, rangeSize) {
+    var startRank,
+        getRange = this.getSearchPrefixRange(rangeSize),
+        collectResults,
+        results = []
+
+    collectResults = range => {
+      range.filter(i => i.substr(i.length - 1) === '*')
+        .filter(i => i.substr(0, prefix.length) === prefix)
+        .forEach(i => results.push(i.substr(0, i.length - 1)))
+
+      if (range.length < rangeSize ||
+          range[range.length - 1].substr(0, prefix.length) !== prefix) {
+        return results
+      }
+      startRank += rangeSize
+      return getRange(startRank).then(collectResults)
+    }
+    return this.getSearchPrefixRank(prefix)
+      .then(rank => startRank = rank)
+      .then(getRange)
+      .then(collectResults)
+  }
+
+  getSearchPrefixRank(prefix) {
+    return new Promise((resolve, reject) => {
+      this.impl.zrank(SEARCH_LINKS_KEY, prefix, promiseDone(resolve, reject))
+    })
+  }
+
+  getSearchPrefixRange(rangeSize) {
+    return startRank => new Promise((resolve, reject) => {
+      if (startRank === null) {
+        return resolve([])
+      }
+      this.impl.zrange(SEARCH_LINKS_KEY, startRank, startRank + rangeSize - 1,
+        promiseDone(resolve, reject))
+    })
+  }
+}
+
+class TargetIndexer {
+  constructor(clientImpl) {
+    this.impl = clientImpl
+  }
+
+  static key(target) {
+    return redisKey('target', target)
+  }
+
+  addLink(link, target) {
+    return new Promise((resolve, reject) => {
+      this.impl.lpush(TargetIndexer.key(target), link,
+        promiseDone(resolve, reject))
+    })
+  }
+
+  reindexLink(link, prevTarget, newTarget) {
+    return prevTarget === newTarget ? Promise.resolve() : Promise.all([
+      this.addLink(link, newTarget),
+      this.removeLink(link, prevTarget)
+    ])
+  }
+
+  removeLink(link, target) {
+    return removeItemFromList(this.impl, TargetIndexer.key(target), link)
+  }
+
+  getLinksToTarget(target) {
+    var getLinks = (resolve, reject) => {
+      this.impl.lrange(TargetIndexer.key(target), 0, -1,
+        promiseDone(resolve, reject))
+    }
+    return new Promise(getLinks).then(links => links.sort())
   }
 }
 
@@ -145,95 +255,20 @@ RedisClient.prototype.createLink = function(link, target, owner) {
 
 RedisClient.prototype.indexLink = function(link, linkInfo) {
   return Promise.all([
-    // Don't store the leading `/` in our link keys.
-    addPrefixesToSearchSet(this.impl, SEARCH_LINKS_KEY, link.slice(1)),
-    addLinkToTargetList(this.impl, linkInfo.target, link)
+    new AutocompleteIndexer(this.impl).addLinkPrefixes(link),
+    new TargetIndexer(this.impl).addLink(link, linkInfo.target)
   ])
-}
-
-// This builds a sorted set of words and their prefixes per:
-// http://oldblog.antirez.com/post/autocomplete-with-redis.html
-function addPrefixesToSearchSet(clientImpl, setName, value) {
-  return new Promise((resolve, reject) => {
-    var args = [setName],
-        endIndex = value.length + 1,
-        i
-
-    for (i = 1; i != endIndex; ++i) {
-      args.push(0)
-      args.push(value.slice(0, i))
-    }
-    args.push(0)
-    args.push(value + '*')
-    args.push(promiseDone(resolve, reject))
-    clientImpl.zadd.apply(clientImpl, args)
-  })
-}
-
-function addLinkToTargetList(clientImpl, target, link) {
-  return new Promise((resolve, reject) => {
-    clientImpl.lpush(targetLinksKey(target), link, promiseDone(resolve, reject))
-  })
 }
 
 RedisClient.prototype.completeLink = function(prefix) {
   const MIN_LINK_PREFIX_SIZE = 3
 
   return prefix.length < MIN_LINK_PREFIX_SIZE ? Promise.resolve([]) :
-    completeString(this, SEARCH_LINKS_KEY, prefix)
-}
-
-// Returns the completed words indexed by addPrefixesToSearchSet() per:
-// http://oldblog.antirez.com/post/autocomplete-with-redis.html
-function completeString(client, setName, prefix) {
-  const rangeSize = client.rangeSize
-  var startRank,
-      getRange = getSearchPrefixRange(client.impl, setName, rangeSize),
-      collectResults,
-      results = []
-
-  collectResults = range => {
-    range.filter(i => i.substr(i.length - 1) === '*')
-      .filter(i => i.substr(0, prefix.length) === prefix)
-      .forEach(i => results.push(i.substr(0, i.length - 1)))
-
-    if (range.length < rangeSize ||
-        range[range.length - 1].substr(0, prefix.length) !== prefix) {
-      return results
-    }
-    startRank += rangeSize
-    return getRange(startRank).then(collectResults)
-  }
-  return getSearchPrefixRank(client.impl, setName, prefix)
-    .then(rank => startRank = rank)
-    .then(getRange)
-    .then(collectResults)
-}
-
-function getSearchPrefixRank(clientImpl, setName, prefix) {
-  return new Promise((resolve, reject) => {
-    clientImpl.zrank(setName, prefix, promiseDone(resolve, reject))
-  })
-}
-
-function getSearchPrefixRange(clientImpl, setName, rangeSize) {
-  return startRank => new Promise((resolve, reject) => {
-    if (startRank === null) {
-      return resolve([])
-    }
-    clientImpl.zrange(setName, startRank, startRank + rangeSize - 1,
-      promiseDone(resolve, reject))
-  })
+    new AutocompleteIndexer(this.impl).completeString(prefix, this.rangeSize)
 }
 
 RedisClient.prototype.getLinksToTarget = function(target) {
-  var getTargetLinks
-
-  getTargetLinks = () => new Promise((resolve, reject) => {
-    this.impl.lrange(targetLinksKey(target), 0, -1,
-      promiseDone(resolve, reject))
-  })
-  return getTargetLinks().then(links => links.sort())
+  return new TargetIndexer(this.impl).getLinksToTarget(target)
 }
 
 RedisClient.prototype.getOwnedLinks = function(owner) {
@@ -266,10 +301,8 @@ RedisClient.prototype.updateProperty = function(link, property, value) {
 }
 
 RedisClient.prototype.reindexLink = function(link, prevInfo, newInfo) {
-  return prevInfo.target === newInfo.target ? Promise.resolve() : Promise.all([
-    addLinkToTargetList(this.impl, newInfo.target, link),
-    removeLinkFromTargetList(this.impl, prevInfo.target, link)
-  ])
+  return new TargetIndexer(this.impl)
+    .reindexLink(link, prevInfo.target, newInfo.target)
 }
 
 RedisClient.prototype.deleteLink = function(link) {
@@ -278,18 +311,7 @@ RedisClient.prototype.deleteLink = function(link) {
 
 RedisClient.prototype.deindexLink = function(link, linkInfo) {
   return Promise.all([
-    // We don't store the leading `/` in our link keys.
-    removeLinkFromSearchSet(this.impl, SEARCH_LINKS_KEY, link.slice(1)),
-    removeLinkFromTargetList(this.impl, linkInfo.target, link)
+    new AutocompleteIndexer(this.impl).removeLink(link),
+    new TargetIndexer(this.impl).removeLink(link, linkInfo.target)
   ])
-}
-
-function removeLinkFromSearchSet(clientImpl, setName, value) {
-  return new Promise((resolve, reject) => {
-    clientImpl.zrem(setName, value + '*', promiseDone(resolve, reject))
-  })
-}
-
-function removeLinkFromTargetList(clientImpl, target, link) {
-  return removeItemFromList(clientImpl, targetLinksKey(target), link)
 }

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -264,3 +264,22 @@ RedisClient.prototype.updateProperty = function(link, property, value) {
 RedisClient.prototype.deleteLink = function(link) {
   return expectResult(1, done => this.impl.del(link, done))
 }
+
+RedisClient.prototype.deindexLink = function(link, linkInfo) {
+  return Promise.all([
+    // We don't store the leading `/` in our link keys.
+    removeLinkFromSearchSet(this.impl, SEARCH_LINKS_KEY, link.slice(1)),
+    removeLinkFromTargetList(this.impl, linkInfo.target, link)
+  ])
+}
+
+function removeLinkFromSearchSet(clientImpl, setName, value) {
+  return new Promise((resolve, reject) => {
+    clientImpl.zrem(setName, value + '*', promiseDone(resolve, reject))
+  })
+}
+
+function removeLinkFromTargetList(clientImpl, target, link) {
+  var key = targetLinksKey(target)
+  return expectResult(1, done => clientImpl.lrem(key, 1, link, done))
+}

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -135,7 +135,7 @@ RedisClient.prototype.createLink = function(link, target, owner) {
           }
           // Note we resolve to the resulting Error if the search set insert
           // fails, since the link actually exists.
-          addLinkToSearchSets(this.impl, link, target)
+          this.indexLink(link, target)
             .then(() => resolve(true))
             .catch(resolve)
         })
@@ -143,11 +143,11 @@ RedisClient.prototype.createLink = function(link, target, owner) {
   })
 }
 
-function addLinkToSearchSets(clientImpl, link, target) {
+RedisClient.prototype.indexLink = function(link, target) {
   return Promise.all([
     // Don't store the leading `/` in our link keys.
-    addPrefixesToSearchSet(clientImpl, SEARCH_LINKS_KEY, link.slice(1)),
-    addLinkToTargetList(clientImpl, target, link)
+    addPrefixesToSearchSet(this.impl, SEARCH_LINKS_KEY, link.slice(1)),
+    addLinkToTargetList(this.impl, target, link)
   ])
 }
 

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -265,6 +265,13 @@ RedisClient.prototype.updateProperty = function(link, property, value) {
     })
 }
 
+RedisClient.prototype.reindexLink = function(link, prevInfo, newInfo) {
+  return prevInfo.target === newInfo.target ? Promise.resolve() : Promise.all([
+    addLinkToTargetList(this.impl, newInfo.target, link),
+    removeLinkFromTargetList(this.impl, prevInfo.target, link)
+  ])
+}
+
 RedisClient.prototype.deleteLink = function(link) {
   return expectResult(1, done => this.impl.del(link, done))
 }

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -63,6 +63,10 @@ function expectResult(expected, func) {
   })
 }
 
+function removeItemFromList(clientImpl, key, item) {
+  return expectResult(1, done => clientImpl.lrem(key, 1, item, done))
+}
+
 RedisClient.prototype.userExists = function(userId) {
   return expectResult(1, done => this.impl.exists(userId, done))
 }
@@ -110,7 +114,7 @@ RedisClient.prototype.addLinkToOwner = function(owner, link) {
 }
 
 RedisClient.prototype.removeLinkFromOwner = function(owner, link) {
-  return expectResult(1, done => this.impl.lrem(owner, 1, link, done))
+  return removeItemFromList(this.impl, owner, link)
 }
 
 RedisClient.prototype.createLink = function(link, target, owner) {
@@ -280,6 +284,5 @@ function removeLinkFromSearchSet(clientImpl, setName, value) {
 }
 
 function removeLinkFromTargetList(clientImpl, target, link) {
-  var key = targetLinksKey(target)
-  return expectResult(1, done => clientImpl.lrem(key, 1, link, done))
+  return removeItemFromList(clientImpl, targetLinksKey(target), link)
 }

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -139,11 +139,11 @@ RedisClient.prototype.createLink = function(link, target, owner) {
   })
 }
 
-RedisClient.prototype.indexLink = function(link, target) {
+RedisClient.prototype.indexLink = function(link, linkInfo) {
   return Promise.all([
     // Don't store the leading `/` in our link keys.
     addPrefixesToSearchSet(this.impl, SEARCH_LINKS_KEY, link.slice(1)),
-    addLinkToTargetList(this.impl, target, link)
+    addLinkToTargetList(this.impl, linkInfo.target, link)
   ])
 }
 

--- a/tests/server/link-db-test.js
+++ b/tests/server/link-db-test.js
@@ -277,10 +277,11 @@ describe('LinkDb', function() {
   })
 
   describe('getLinkIfOwner', function() {
-    it('successfully validates ownership', function() {
+    it('returns the link info object if ownership validation succeeds', () => {
       stubClientMethod('getLink').withArgs('/foo')
         .returns(Promise.resolve({ owner: 'mbland' }))
-      return linkDb.getLinkIfOwner('/foo', 'mbland').should.be.fulfilled
+      return linkDb.getLinkIfOwner('/foo', 'mbland')
+        .should.become({ owner: 'mbland' })
     })
 
     it('fails if the link doesn\'t exist', function() {

--- a/tests/server/link-db-test.js
+++ b/tests/server/link-db-test.js
@@ -276,24 +276,24 @@ describe('LinkDb', function() {
     })
   })
 
-  describe('checkOwnership', function() {
+  describe('getLinkIfOwner', function() {
     it('successfully validates ownership', function() {
       stubClientMethod('getLink').withArgs('/foo')
         .returns(Promise.resolve({ owner: 'mbland' }))
-      return linkDb.checkOwnership('/foo', 'mbland').should.be.fulfilled
+      return linkDb.getLinkIfOwner('/foo', 'mbland').should.be.fulfilled
     })
 
     it('fails if the link doesn\'t exist', function() {
       stubClientMethod('getLink').withArgs('/foo')
         .returns(Promise.resolve(null))
-      return linkDb.checkOwnership('/foo', 'mbland')
+      return linkDb.getLinkIfOwner('/foo', 'mbland')
         .should.be.rejectedWith('/foo does not exist')
     })
 
     it('fails unless invoked by the owner', function() {
       stubClientMethod('getLink').withArgs('/foo')
         .returns(Promise.resolve({ owner: 'msb' }))
-      return linkDb.checkOwnership('/foo', 'mbland')
+      return linkDb.getLinkIfOwner('/foo', 'mbland')
         .should.be.rejectedWith('/foo is owned by msb')
     })
   })

--- a/tests/server/redis-client-test.js
+++ b/tests/server/redis-client-test.js
@@ -305,7 +305,7 @@ describe('RedisClient', function() {
 
   describe('indexLink', function() {
     it('should successfully index a link', () => {
-      return redisClient.indexLink('/foobar', LINK_TARGET)
+      return redisClient.indexLink('/foobar', { target: LINK_TARGET })
         .should.be.fulfilled
         .then(() => redisClient.completeLink('foo'))
         .should.become(['foobar'])
@@ -319,7 +319,7 @@ describe('RedisClient', function() {
         cb(new Error('forced error for ' + args.join(' ')))
       })
 
-      return redisClient.indexLink('/foo', LINK_TARGET)
+      return redisClient.indexLink('/foo', { target: LINK_TARGET })
         .should.be.rejectedWith(Error,
           'forced error for search:links 0 f 0 fo 0 foo 0 foo*')
     })
@@ -468,11 +468,11 @@ describe('RedisClient', function() {
   describe('completeLink', function() {
     beforeEach(function() {
       return Promise.all([
-        redisClient.indexLink('/foobar', LINK_TARGET),
-        redisClient.indexLink('/bar', LINK_TARGET),
-        redisClient.indexLink('/barbaz', LINK_TARGET),
-        redisClient.indexLink('/barquux', LINK_TARGET),
-        redisClient.indexLink('/baz', LINK_TARGET)
+        redisClient.indexLink('/foobar', { target: LINK_TARGET }),
+        redisClient.indexLink('/bar', { target: LINK_TARGET }),
+        redisClient.indexLink('/barbaz', { target: LINK_TARGET }),
+        redisClient.indexLink('/barquux', { target: LINK_TARGET }),
+        redisClient.indexLink('/baz', { target: LINK_TARGET })
       ])
     })
 
@@ -497,9 +497,9 @@ describe('RedisClient', function() {
   describe('getLinksToTarget', function() {
     beforeEach(function() {
       return Promise.all([
-        redisClient.indexLink('/foo', LINK_TARGET),
-        redisClient.indexLink('/bar', LINK_TARGET),
-        redisClient.indexLink('/baz', LINK_TARGET)
+        redisClient.indexLink('/foo', { target: LINK_TARGET }),
+        redisClient.indexLink('/bar', { target: LINK_TARGET }),
+        redisClient.indexLink('/baz', { target: LINK_TARGET })
       ])
     })
 


### PR DESCRIPTION
Adds `deindexLink()` and `reindexLink()` methods to `RedisClient`, as well as moves the previously private `addLinkToSearchSets()` to `RedisClient.indexLink()`.

This also renames `LinkDb.checkOwnership()` to `LinkDb.getLinkIfOwner()`, which now returns the link info object it uses to validate ownership. This will make dispatching to the `RedisClient` indexing methods more efficient.

The next PR will do some more refactoring between `RedisClient` and `LinkDb` in an effort to better separate concerns.