### PR TITLE
LinkDb: Fix searchShortLinks, return object

### DIFF
--- a/lib/link-db.js
+++ b/lib/link-db.js
@@ -89,7 +89,7 @@ LinkDb.prototype.getLinkIfOwner = function(link, user) {
 
 LinkDb.prototype.searchShortLinks = function(searchString) {
   return this.client.searchShortLinks(searchString)
-    .then(this.fetchLinkData)
+    .then(results => { return { results } })
 }
 
 LinkDb.prototype.searchTargetLinks = function(searchString) {

--- a/tests/server/link-db-test.js
+++ b/tests/server/link-db-test.js
@@ -299,6 +299,32 @@ describe('LinkDb', function() {
     })
   })
 
+  describe('searchShortLinks', function() {
+    it('returns all matching links', () => {
+      const links = [
+        {
+          link: '/baz',
+          owner: 'mbland'
+        },
+        {
+          link: '/bar',
+          owner: 'mbland'
+        },
+        {
+          link: '/foo',
+          owner: 'mbland'
+        }
+      ]
+      const matchingLinks = [links[1], links[0]]
+
+      stubClientMethod('searchShortLinks')
+        .withArgs('ba')
+        .returns(Promise.resolve(matchingLinks))
+      return linkDb.searchShortLinks('ba')
+        .should.become({ results: matchingLinks })
+    })
+  })
+
   describe('searchTargetLinks', function() {
     it('returns all links', () => {
       const mblandLinks =  [


### PR DESCRIPTION
The first problem with the previous implementation (other than we forgot to test it) was that the underlying RedisClient.searchShortLinks() was already returning linkInfo objects. Consequently, the call to RedisClient.fetchLinkData() was not only superflouous, but causing server errors, because it expects an array of strings, not an array of objects.

The second problem was that it returned an array, passed through the API as a JSON array, which has presented various security vulnerabilities over time (do a quick search on "json array security"). Wrapping arrays in an object is still recommended by OWASP:

https://www.owasp.org/index.php/AJAX_Security_Cheat_Sheet#Always_return_JSON_with_an_Object_on_the_outside