### PR TITLE
Migration for autocomplete, target URL indexes

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,6 +1,8 @@
 instrumentation:
   include-all-sources: true
   excludes:
+  - bin/*
+  - lib/redis/migrations/*
   - public/assets/js/vendor/*
   - public/tests/generated/*
   - public/tests/vendor/*

--- a/bin/run-migrations
+++ b/bin/run-migrations
@@ -1,0 +1,46 @@
+#! /usr/bin/env node
+//
+// Runs a series of idempotent migration scripts to transform an existing
+// Custom Links database to a new schema.
+//
+// Usage:
+//   REDIS_HOST=<hostname> REDIS_PORT=<port> run-migrations
+//
+// Where:
+//   <hostname>  name of host on which Redis is running (default: localhost)
+//   <port>      port on which Redis is listening (default: 6379)
+
+var Log = require('log')
+var log = new Log('info')
+
+var redis = require('redis')
+var redisClientOptions = {
+  host: process.env.REDIS_HOST,
+  port: process.env.REDIS_PORT
+}
+var redisClient = redis.createClient(redisClientOptions)
+
+var path = require('path')
+
+const MIGRATIONS_DIR = '../lib/redis/migrations/'
+const MIGRATION_NAMES = [
+  '0000-target-search-autocomplete'
+]
+
+Promise
+  .all(MIGRATION_NAMES.map(migrationName => {
+    var Migration = require(path.join(MIGRATIONS_DIR, migrationName))
+
+    log.info(`migration ${migrationName} started`)
+    return new Migration(redisClient, log).migrate()
+      .then(() => {
+        log.info(`migration ${migrationName} complete`)
+      })
+      .catch(err => {
+        log.error(`migration ${migrationName} failed: ${err}`)
+        return err
+      })
+  }))
+  .then(results => {
+    process.exit(results.filter(i => i !== undefined).length)
+  })

--- a/lib/redis/migrations/0000-target-search-autocomplete.js
+++ b/lib/redis/migrations/0000-target-search-autocomplete.js
@@ -1,0 +1,41 @@
+'use strict'
+
+var PromiseHelper = require('../promise-helper')
+var SearchHelper = require('../search-helper')
+var AutocompleteIndexer = require('../autocomplete-indexer')
+var TargetIndexer = require('../target-indexer')
+var Keys = require('../keys')
+
+module.exports = TargetSearchAndAutocompleteMigration
+
+// Generates autocomplete and target URL search indexes from existing data.
+function TargetSearchAndAutocompleteMigration(redisClient, log) {
+  this.impl = redisClient
+  this.log = log
+}
+
+TargetSearchAndAutocompleteMigration.prototype.migrate = function() {
+  return new SearchHelper(this.impl, '*', Keys.SHORT_LINK_PREFIX).scan()
+    .then(links => createAutocompleteIndex(this.impl, this.log, links))
+    .then(links => createTargetUrlIndex(this.impl, this.log, links))
+}
+
+function createAutocompleteIndex(client, log, links) {
+  var indexer = new AutocompleteIndexer(client)
+  log.info('creating autocomplete index for custom links')
+  return PromiseHelper.map(links, link => indexer.addLink(link))
+    .then(() => links)
+}
+
+function createTargetUrlIndex(client, log, links) {
+  var indexer = new TargetIndexer(client)
+  log.info('creating search index for target URLs')
+  return PromiseHelper
+    .map(links, link => new Promise((res, rej) => {
+      client.hgetall(link, (err, linkData) => err ? rej(err) : res(linkData))
+    }))
+    .then(results => PromiseHelper.map(results, (linkData, i) => {
+      return indexer.addLink(links[i], linkData)
+    }))
+    .then(() => links)
+}


### PR DESCRIPTION
The migration script builds the autocomplete and target URL indexes from the existing data. New custom links will be indexed by the server automatically. This script is idempotent, so running it multiple times will not have an impact on the consistency of the database.

The `run-migrations` script allows for multiple migrations to run in the future.

While I don't have tests for these new scripts, the underlying classes they use are the same as those used by the Custom Links server itself, and are thoroughly tested. (Still, I feel like I should have some...I'll create a tech debt ticket if asked!)