### PR TITLE
Add the search user interface

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -323,21 +323,22 @@
   }
 
   cl.createSearchResultsTable = function(queryType, results) {
-    var resultTable = cl.getTemplate('search-results'),
-        searchResult = cl.getTemplate('search-result'),
-        linkIndex = 0,
-        targetIndex = 1
+    var params = {
+      resultTable: cl.getTemplate('search-results'),
+      entryTemplate: cl.getTemplate('search-result'),
+      linkIndex: 0,
+      targetIndex: 1
+    }
 
     if (queryType === cl.TARGET_URL_QUERY) {
-      cl.swapSearchResultTableHeaders(resultTable, searchResult)
-      targetIndex = 0
-      linkIndex = 1
-      results = cl.transformTargetSearchResults(results)
+      cl.swapSearchResultTableHeaders(params.resultTable, params.entryTemplate)
+      params.targetIndex = 0
+      params.linkIndex = 1
+      params.results = cl.transformTargetSearchResults(results)
     } else {
-      results = results.results
+      params.results = results.results
     }
-    return cl.fillSearchResultsTable(results, resultTable, searchResult,
-      linkIndex, targetIndex)
+    return cl.fillSearchResultsTable(params)
   }
 
   cl.swapSearchResultTableHeaders = function(resultTable, entryTemplate) {
@@ -362,21 +363,20 @@
       }, [])
   }
 
-  cl.fillSearchResultsTable = function(results, resultTable, entryTemplate,
-    linkIndex, targetIndex) {
-    results.forEach(function(link) {
-      var current = entryTemplate.cloneNode(true),
+  cl.fillSearchResultsTable = function(params) {
+    params.results.forEach(function(link) {
+      var current = params.entryTemplate.cloneNode(true),
           cells = current.getElementsByClassName('cell')
 
-      cells[linkIndex].appendChild(cl.createAnchor(link.link))
-      cells[targetIndex].appendChild(cl.createAnchor(link.target))
+      cells[params.linkIndex].appendChild(cl.createAnchor(link.link))
+      cells[params.targetIndex].appendChild(cl.createAnchor(link.target))
       cells[2].textContent = cl.dateStamp(link.created)
       cells[3].textContent = cl.dateStamp(link.updated)
       cells[4].textContent = link.owner
       cells[5].textContent = link.clicks
-      resultTable.appendChild(current)
+      params.resultTable.appendChild(current)
     })
-    return resultTable
+    return params.resultTable
   }
 
   cl.errorView = function(message) {

--- a/public/index.html
+++ b/public/index.html
@@ -34,7 +34,7 @@ body{margin-top:30px;}
 @media (min-width:850px){
 .timestamp.cell{width:100px;word-break:normal;}
 .link-target{display:flex;flex:1;}
-.links-header .clicks-action{width:215px;}
+.links-row .clicks-action{width:215px;}
 .links .cell{flex:0 0 100px;}
 .links button{margin:2px;}
 .links-data .action{display:flex;flex:0 0 215px;}
@@ -49,6 +49,7 @@ body{margin-top:30px;}
         <span id='userid'></span> |
         <a href='/#'>My&nbsp;links</a> |
         <a href='/#create'>New&nbsp;link</a> |
+        <a href='/#search'>Search</a> |
         <a href='/logout'>Log&nbsp;out</a>
       </div>
       <h3>Custom Links</h3>
@@ -155,6 +156,41 @@ body{margin-top:30px;}
         </p>
         <button class='confirm'>Yes</button>
         <button class='focused cancel button-primary'>No</button>
+      </div>
+      <form class='search-view' action='/api/search'>
+        <input class='u-full-width' data-name='query'/>
+        <button class='button-primary' type='submit'>Search links</button>
+        <button class='button-primary' type='submit'>Search targets</button>
+        <div class='results'></div>
+      </form>
+      <div class='search-results links'>
+        <div class='links-row links-header'>
+          <div class='wrapper link-target'>
+            <div class='label cell link'>Link</div>
+            <div class='label cell target'>Target</div>
+            <div class='label cell timestamp created'>Created</div>
+            <div class='label cell timestamp updated'>Updated</div>
+          </div>
+          <div class='wrapper clicks-action'>
+            <div class='label cell owner'>Owner</div>
+            <div class='label cell clicks'>Clicks</div>
+          </div>
+        </div>
+      </div>
+      <div class='search-result link links-row links-data'>
+        <div class='wrapper link-target'>
+          <div class='cell link'></div>
+          <div class='cell target'></div>
+          <div class='cell timestamp created'></div>
+          <div class='cell timestamp updated'></div>
+        </div>
+        <div class='wrapper clicks-action'>
+          <div class='cell owner'></div>
+          <div class='cell clicks'></div>
+        </div>
+      </div>
+      <div class='search-no-results result success'>
+        <p>No matching links found.</p>
       </div>
     </div>
   </div>

--- a/tests/end-to-end/end-to-end.js
+++ b/tests/end-to-end/end-to-end.js
@@ -128,6 +128,7 @@ test.describe('End-to-end test', function() {
     // make sure we can navigate to "New link" in the nav bar as expected.
     activeElement().sendKeys(Key.chord(Key.SHIFT, Key.TAB))
     activeElement().sendKeys(Key.chord(Key.SHIFT, Key.TAB))
+    activeElement().sendKeys(Key.chord(Key.SHIFT, Key.TAB))
     activeElement().getText().should.become('New link')
     activeElement().sendKeys(Key.ENTER)
     driver.wait(until.urlIs(url + '#create'))
@@ -245,5 +246,48 @@ test.describe('End-to-end test', function() {
     driver.findElement(By.linkText('My links')).click()
     driver.wait(until.urlIs(url + '#'))
     waitForActiveLink('Create a new custom link')
+  })
+
+  test.it('searches for links and target URLs', function() {
+    createNewLink('foo', url + 'foo')
+    createNewLink('bar', url + 'bar')
+    createNewLink('baz', url + 'baz')
+
+    driver.findElement(By.linkText('Search')).click()
+    driver.wait(until.urlIs(url +'#search'))
+    waitForFormInput()
+
+    // Enter the search term, tab to the "Search links" button, and click
+    activeElement().sendKeys('[fb]', Key.TAB)
+    activeElement().click()
+
+    driver.wait(until.elementLocated(By.css('.search-results'), 3000,
+      'timeout waiting for search results to appear'))
+    driver.wait(until.elementLocated(By.linkText('/foo')), 3000,
+      'timeout waiting for first search result to appear')
+    driver.findElement(By.linkText('/bar'))
+    driver.findElement(By.linkText('/baz'))
+
+    // Tab over to the "Search targets" link and click it; should produce the
+    // same results.
+
+    activeElement().sendKeys(Key.TAB)
+    activeElement().click()
+
+    driver.wait(until.elementLocated(By.css('.search-results'), 3000,
+      'timeout waiting for search results to appear'))
+    driver.wait(until.elementLocated(By.linkText('/foo')), 3000,
+      'timeout waiting for first search result to appear')
+    driver.findElement(By.linkText('/bar'))
+    driver.findElement(By.linkText('/baz'))
+
+    // Now enter a query that matches nothing and ensure the results are empty.
+    activeElement().sendKeys(Key.chord(Key.SHIFT, Key.TAB))
+    activeElement().sendKeys(Key.chord(Key.SHIFT, Key.TAB))
+    activeElement().sendKeys('quux', Key.TAB)
+    activeElement().click()
+
+    driver.wait(until.elementLocated(By.css('.search-no-results'), 3000,
+      'timeout waiting for empty search results message to appear'))
   })
 })


### PR DESCRIPTION
Closes #161, #165. It's rudimentary, but enables the user to search by both custom links and their target URLs.

Since the underlying database is Redis, it accepts any glob-style pattern that can be passed as an argument to scan().

cc: @unhuman, @mpdatx 