### PR TITLE
API: Add /autocomplete endpoint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -152,12 +152,18 @@ function assembleApiRouter(linkDb, logger) {
     } else if (req.query.target) {
       search = linkDb.searchTargetLinks(req.query.target)
     } else {
-      res.status(400)
+      return res.sendStatus(400)
     }
 
     search.then(results => {
       res.status(200).json(results)
     }).catch(errorHandler(req, res, logger, 'json'))
+  })
+
+  router.get('/autocomplete' + linkParam, (req, res) => {
+    linkDb.completeLink(req.params.link.slice(1))
+      .then(results => res.status(200).json({ results }))
+      .catch(errorHandler(req, res, logger, 'json'))
   })
 
   router.all('/*', (req, res) => res.sendStatus(400))

--- a/lib/link-db.js
+++ b/lib/link-db.js
@@ -109,6 +109,10 @@ LinkDb.prototype.searchTargetLinks = function(searchString) {
     })
 }
 
+LinkDb.prototype.completeLink = function(prefix) {
+  return this.client.completeLink(prefix)
+}
+
 LinkDb.prototype.updateProperty = function(link, user, property, value) {
   return this.getLinkIfOwner(link, user)
     .then(() => {


### PR DESCRIPTION
Part of #160. This is more or less a straight passthrough to LinkDb.completeLink(), which passes through to RedisClient.completeLink().

Also moved the `/api/search` test to be part of the `API` block, and tweaked the error path in that API endpoint to avoid emitting `Cannot read property 'then' of undefined` output, as in:

https://travis-ci.org/mbland/custom-links/jobs/371712950
